### PR TITLE
Add CUDA provider to sherpa-onnx / Parakeet transcriber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG SHERPA_ONNX_GPU_WHEEL="1.12.20+cuda12.cudnn9"
 
 # Install faster-whisper
 WORKDIR /usr/src
@@ -9,6 +10,7 @@ COPY ./pyproject.toml ./
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
+        libasound2 \
         python3 \
         python3-pip \
         python3-venv \
@@ -24,6 +26,10 @@ RUN \
     && .venv/bin/pip3 install --no-cache-dir \
         --extra-index-url https://www.piwheels.org/simple \
         -e '.[zeroconf,transformers,sherpa,onnx-asr]' \
+    && .venv/bin/pip3 uninstall -y sherpa-onnx sherpa-onnx-core \
+    && .venv/bin/pip3 install --no-cache-dir \
+        "sherpa-onnx==${SHERPA_ONNX_GPU_WHEEL}" \
+        -f https://k2-fsa.github.io/sherpa/onnx/cuda.html \
     \
     && rm -rf /var/lib/apt/lists/*
 

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -134,7 +134,10 @@ class ModelLoader:
                 from .sherpa_handler import SherpaTranscriber  # noqa: F811
 
                 transcriber = SherpaTranscriber(
-                    model, self.download_dir, cpu_threads=self.cpu_threads
+                    model,
+                    self.download_dir,
+                    device=self.device,
+                    cpu_threads=self.cpu_threads,
                 )
             elif stt_library == SttLibrary.ONNX_ASR:
                 from .onnx_asr_handler import OnnxAsrTranscriber  # noqa: F811

--- a/wyoming_faster_whisper/sherpa_handler.py
+++ b/wyoming_faster_whisper/sherpa_handler.py
@@ -26,6 +26,7 @@ class SherpaTranscriber(Transcriber):
         self,
         model_id: str,
         cache_dir: Union[str, Path],
+        device: str = "cpu",
         cpu_threads: int = 4,
     ) -> None:
         """Initialize model."""
@@ -51,6 +52,9 @@ class SherpaTranscriber(Transcriber):
                 shutil.rmtree(model_dir, ignore_errors=True)
                 raise
 
+        provider = "cuda" if device.startswith("cuda") else "cpu"
+        _LOGGER.info("Loading sherpa model with provider=%s", provider)
+
         # Load model
         self.recognizer = so.OfflineRecognizer.from_transducer(
             num_threads=cpu_threads,
@@ -58,7 +62,7 @@ class SherpaTranscriber(Transcriber):
             decoder=f"{model_dir}/decoder.int8.onnx",
             joiner=f"{model_dir}/joiner.int8.onnx",
             tokens=f"{model_dir}/tokens.txt",
-            provider="cpu",
+            provider=provider,
             model_type="nemo_transducer",
         )
 


### PR DESCRIPTION
I assume you may want this done differently but I wanted to use my gpu for parakeet and this was the minimal change required.

Pass --device through to SherpaTranscriber so users can enable GPU acceleration (e.g. --device cuda). Derives ONNX Runtime provider from the device string ("cuda*" → CudaExecutionProvider, else CPU). Also installs a CUDA-compiled sherpa-onnx wheel in Docker and adds libasound2 dependency for Linux audio support.


