### PR TITLE
Bias transcription toward Home Assistant names, and make the Qwen3-ASR prompt cheap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Names are added to the prompt in priority order (areas, floors, entity names, aliases) up to `--hass-prompt-max-tokens` (default 200, Whisper's hard cap is 223); `--initial-prompt` is kept at the front
 - Add `--hass-api`, `--hass-refresh-seconds`, `--hass-prompt-max-tokens`, and `--hass-prompt-timeout`
 
+- Qwen3-ASR: support a merged decoder export (`decoder_merged.int4.onnx`) that takes a KV cache and a dynamic sequence length, so the biasing prompt's KV is computed once and reused instead of being re-prefilled every utterance. On a Pi 5 with a 50-name prompt, a 3.2s command goes from 3.42s to 2.20s (1.56x), peak RSS from 2.25 GB to 1.55 GB, and the package from 1407 MB to 785 MB
+- The merged layout is selected automatically when `decoder_merged.int4.onnx` is present; model directories with `decoder_init`/`decoder_step` keep working unchanged
+- The speedup applies to short commands. Long-form audio sees ~1.04x, since the cached prompt is a small share of the work — but the memory saving grows with length (4.16 GB → 2.87 GB on a 30s clip)
+
 - Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4)
 - `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
 - Qwen3-ASR is opt-in only (`auto` never selects it): the model is 1.4 GB and needs ~1.7 GB of RAM, and it is slower than the per-language defaults

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 - Qwen3-ASR: support a merged decoder export (`decoder_merged.int4.onnx`) that takes a KV cache and a dynamic sequence length, so the biasing prompt's KV is computed once and reused instead of being re-prefilled every utterance. On a Pi 5 with a 50-name prompt, a 3.2s command goes from 3.42s to 2.20s (1.56x), peak RSS from 2.25 GB to 1.55 GB, and the package from 1407 MB to 785 MB
 - The merged layout is selected automatically when `decoder_merged.int4.onnx` is present; model directories with `decoder_init`/`decoder_step` keep working unchanged
 - The speedup applies to short commands. Long-form audio sees ~1.04x, since the cached prompt is a small share of the work — but the memory saving grows with length (4.16 GB → 2.87 GB on a 30s clip)
+- The default Qwen3-ASR model is now the merged export. On LibriSpeech test-other (n=200) it transcribes byte-identically to the split export with no prompt (5.35% WER for both), and scores 5.33% vs 5.43% with a 50-name prompt — a difference well inside sampling noise. Pass `--model rhasspy/qwen3-asr-0.6b-onnx-int4` for the split export, which stays published
 
-- Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4)
+- Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4-merged`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4-merged)
 - `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
-- Qwen3-ASR is opt-in only (`auto` never selects it): the model is 1.4 GB and needs ~1.7 GB of RAM, and it is slower than the per-language defaults
+- Qwen3-ASR is opt-in only (`auto` never selects it): the model is 785 MB and needs ~1.6 GB of RAM, and it is slower than the per-language defaults
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add `--hass-token` (extra: `hass`) to bias transcription toward the names in Home Assistant: conversation-exposed entity names and aliases, plus area and floor names, read over the websocket API and passed to the model as a prompt (fixes e.g. "What's the temperature of the incubi?" → "What's the temperature of the Ecobee?")
+- Names are refreshed in the background starting at `AudioStart`, so the fetch finishes while the speaker is still talking and adds no latency; a slow or unreachable Home Assistant falls back to the previous names and never fails a transcript
+- Names are added to the prompt in priority order (areas, floors, entity names, aliases) up to `--hass-prompt-max-tokens` (default 200, Whisper's hard cap is 223); `--initial-prompt` is kept at the front
+- Add `--hass-api`, `--hass-refresh-seconds`, `--hass-prompt-max-tokens`, and `--hass-prompt-timeout`
+
 - Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4)
 - `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
 - Qwen3-ASR is opt-in only (`auto` never selects it): the model is 1.4 GB and needs ~1.7 GB of RAM, and it is slower than the per-language defaults

--- a/README.md
+++ b/README.md
@@ -28,6 +28,53 @@ The `--model` can also be a HuggingFace model like `Systran/faster-distil-whispe
 
 **NOTE**: Models are downloaded to the first `--data-dir` directory.
 
+## Biasing Toward Your Home Assistant Names
+
+Whisper has never heard of your thermostat. "What's the temperature of the Ecobee?"
+comes back as "What's the temperature of the incubi?" — the acoustics were fine,
+the model just has no reason to think that word exists.
+
+Given a long-lived access token, the server reads the names in your home over the
+Home Assistant websocket API and feeds them to the model as a prompt, which fixes
+exactly that class of error:
+
+```sh
+script/run --uri 'tcp://0.0.0.0:10300' --data-dir /data \
+    --hass-token "$TOKEN" --hass-api 'http://homeassistant.local:8123/api'
+```
+
+Requires the `hass` extra:
+
+```sh
+pip install 'wyoming-faster-whisper[hass]'
+```
+
+It collects the names of **conversation-exposed** entities and their aliases, plus
+your area and floor names — the names a speaker can actually say. Nothing else is
+read, and no service is ever called.
+
+The fetch is free in latency terms: it starts when the audio starts, while the
+speaker is still talking, and the names are ready by the time the audio stops.
+Home Assistant being slow or unreachable only costs freshness — the previous names
+are used, or none at all, and the transcript still comes back.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--hass-token` | | Long-lived access token. Enables everything above. |
+| `--hass-api` | `http://homeassistant.local:8123/api` | Where to find Home Assistant. |
+| `--hass-refresh-seconds` | `0` | Minimum seconds between refreshes. `0` refreshes every utterance, so a rename takes effect immediately. |
+| `--hass-prompt-max-tokens` | `200` | Token budget for names. Whisper's hard cap is 223 and quality falls off before it. |
+| `--hass-prompt-timeout` | `1.0` | How long to wait on an unfinished refresh before transcribing with the names already on hand. |
+
+A large home has more names than the budget holds. They are added in priority
+order — areas, floors, entity names, then aliases — and cut off when the budget
+runs out; run with `--debug` to see how many were dropped and the exact prompt
+used. `--initial-prompt` still works and is kept at the front of the prompt, ahead
+of anything discovered from Home Assistant.
+
+This biases `faster-whisper` and `qwen3-asr`, the backends that take a prompt.
+Others ignore it.
+
 ## Docker Image
 
 ``` sh

--- a/README.md
+++ b/README.md
@@ -79,14 +79,17 @@ Others ignore it.
 
 For `qwen3-asr` the prompt is not free: the model has to read it before it starts
 decoding, at roughly 2.8ms per token, so a 50-name list can double the time for a
-short command. A model directory containing `decoder_merged.int4.onnx` avoids
-this — the prompt sits ahead of the audio in the chat template, so its state is
-computed once and reused for every later utterance. It is selected automatically;
-directories with `decoder_init`/`decoder_step` keep working as before.
+short command.
+
+The default model avoids this. The prompt sits ahead of the audio in the chat
+template, so its state depends only on the prompt and is computed once, then
+reused for every later utterance. The layout is chosen from the files present, so
+older model directories with `decoder_init`/`decoder_step` keep working as before
+— pass `--model rhasspy/qwen3-asr-0.6b-onnx-int4` to use one.
 
 Measured on a Pi 5 (4 threads, 3.2s command, 50 names):
 
-| | split | merged |
+| | split | merged (default) |
 | --- | --- | --- |
 | latency | 3.42s | 2.20s |
 | peak RSS | 2.25 GB | 1.55 GB |
@@ -95,6 +98,10 @@ Measured on a Pi 5 (4 threads, 3.2s command, 50 names):
 The latency win is for short commands. Long-form audio gains little (~1.04x on a
 30s clip), because the cached prompt is a small share of that work — though the
 memory saving grows with length.
+
+Accuracy is unchanged: on LibriSpeech test-other (n=200) the two produce
+byte-identical transcripts with no prompt (5.35% WER for both), and 5.33% vs
+5.43% with a 50-name prompt.
 
 ## Docker Image
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ of anything discovered from Home Assistant.
 This biases `faster-whisper` and `qwen3-asr`, the backends that take a prompt.
 Others ignore it.
 
+### Prompt cost on qwen3-asr
+
+For `qwen3-asr` the prompt is not free: the model has to read it before it starts
+decoding, at roughly 2.8ms per token, so a 50-name list can double the time for a
+short command. A model directory containing `decoder_merged.int4.onnx` avoids
+this — the prompt sits ahead of the audio in the chat template, so its state is
+computed once and reused for every later utterance. It is selected automatically;
+directories with `decoder_init`/`decoder_step` keep working as before.
+
+Measured on a Pi 5 (4 threads, 3.2s command, 50 names):
+
+| | split | merged |
+| --- | --- | --- |
+| latency | 3.42s | 2.20s |
+| peak RSS | 2.25 GB | 1.55 GB |
+| on disk | 1407 MB | 785 MB |
+
+The latency win is for short commands. Long-form audio gains little (~1.04x on a
+30s clip), because the cached prompt is a small share of that work — though the
+memory saving grows with length.
+
 ## Docker Image
 
 ``` sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ qwen3_asr = [
     "onnxruntime>=1.18.1",
     "tokenizers>=0.20",
 ]
+hass = [
+    "aiohttp>=3.8,<4",
+]
 zeroconf = [
     "wyoming[zeroconf]",
 ]

--- a/tests/test_dispatch_handler.py
+++ b/tests/test_dispatch_handler.py
@@ -1,0 +1,408 @@
+"""Tests for what the dispatch handler actually hands the transcriber.
+
+Drives real Wyoming events through ``handle_event`` with a fake transcriber and
+loader, so the whole biasing path is covered in-process: AudioStart starts the
+refresh, AudioStop waits for it, and the resulting prompt reaches
+``transcribe()``. No model and no network.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import pytest
+
+pytest.importorskip("aiohttp")
+
+# pylint: disable=wrong-import-position
+from wyoming.asr import Transcribe, Transcript  # noqa: E402
+from wyoming.audio import AudioChunk, AudioStart, AudioStop  # noqa: E402
+from wyoming.info import Info  # noqa: E402
+
+from wyoming_faster_whisper.const import StreamingSession, Transcriber  # noqa: E402
+from wyoming_faster_whisper.dispatch_handler import DispatchEventHandler  # noqa: E402
+from wyoming_faster_whisper.hass_api import HomeAssistantError  # noqa: E402
+from wyoming_faster_whisper.name_cache import HassNameCache  # noqa: E402
+from wyoming_faster_whisper.vocabulary import RecognitionContext  # noqa: E402
+
+RATE = 16000
+
+
+class FakeSession(StreamingSession):
+    """Records the prompt its stream was opened with."""
+
+    def __init__(self, initial_prompt: Optional[str]) -> None:
+        self.initial_prompt = initial_prompt
+        self.chunks: List[bytes] = []
+
+    def accept_chunk(self, audio_bytes: bytes) -> None:
+        self.chunks.append(audio_bytes)
+
+    def finish(self) -> str:
+        return "streamed transcript"
+
+
+class FakeTranscriber(Transcriber):
+    """Captures every call, and can pretend to have (or lack) a tokenizer."""
+
+    def __init__(
+        self,
+        streaming: bool = False,
+        tokens_per_word: Optional[int] = None,
+    ) -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self.sessions: List[FakeSession] = []
+        self._streaming = streaming
+        self._tokens_per_word = tokens_per_word
+
+    def transcribe(
+        self,
+        wav_path: Union[str, Path],
+        language: Optional[str],
+        beam_size: int = 5,
+        initial_prompt: Optional[str] = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "language": language,
+                "beam_size": beam_size,
+                "initial_prompt": initial_prompt,
+            }
+        )
+        return "fake transcript"
+
+    def count_prompt_tokens(self, text: str) -> Optional[int]:
+        if self._tokens_per_word is None:
+            # Stands in for a backend with no tokenizer to ask.
+            return None
+
+        return len(text.split()) * self._tokens_per_word
+
+    @property
+    def supports_streaming(self) -> bool:
+        return self._streaming
+
+    def start_stream(
+        self,
+        language: Optional[str] = None,
+        beam_size: int = 5,
+        initial_prompt: Optional[str] = None,
+    ) -> StreamingSession:
+        session = FakeSession(initial_prompt)
+        self.sessions.append(session)
+        return session
+
+    @property
+    def prompt(self) -> Optional[str]:
+        """The prompt from the last transcribe() call."""
+        assert self.calls, "transcribe() was never called"
+        return self.calls[-1]["initial_prompt"]
+
+
+class FakeLoader:
+    """Just the attributes DispatchEventHandler reads off ModelLoader."""
+
+    def __init__(
+        self, transcriber: FakeTranscriber, initial_prompt: Optional[str] = None
+    ) -> None:
+        self.transcriber = transcriber
+        self.initial_prompt = initial_prompt
+        self.beam_size = 5
+        self.preferred_language = "en"
+        self.vad_clip = False
+        self.vad_clip_threshold = 0.5
+        self.vad_clip_pad_ms = 400
+
+    async def load_transcriber(self, language: Optional[str] = None) -> Transcriber:
+        return self.transcriber
+
+
+class FakeHass:
+    """Stands in for HomeAssistant."""
+
+    def __init__(self, context: Optional[RecognitionContext] = None, delay=0.0) -> None:
+        self.context = context if context is not None else RecognitionContext()
+        self.delay = delay
+        self.fail = False
+        self.calls = 0
+
+    async def get_context(self) -> RecognitionContext:
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+
+        if self.fail:
+            raise HomeAssistantError("unreachable")
+
+        return self.context
+
+
+class Handler(DispatchEventHandler):
+    """Captures written events instead of needing a socket."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.written: List[Any] = []
+        super().__init__(*args, **kwargs)
+
+    async def write_event(self, event) -> None:
+        self.written.append(event)
+
+    @property
+    def transcript(self) -> str:
+        for event in self.written:
+            if Transcript.is_type(event.type):
+                return Transcript.from_event(event).text
+
+        raise AssertionError("no transcript was written")
+
+
+def _names(*entities) -> RecognitionContext:
+    return RecognitionContext(entities=list(entities))
+
+
+def _handler(transcriber, names=None, initial_prompt=None) -> Handler:
+    return Handler(Info(), FakeLoader(transcriber, initial_prompt), names, None, None)
+
+
+def _cache(hass, **kwargs) -> HassNameCache:
+    kwargs.setdefault("max_tokens", 1000)
+    return HassNameCache(hass, **kwargs)
+
+
+async def _utterance(handler: Handler, chunks: int = 3, pace: float = 0.0) -> None:
+    """One full request, the way Home Assistant sends it."""
+    await handler.handle_event(Transcribe(language="en").event())
+    await handler.handle_event(AudioStart(rate=RATE, width=2, channels=1).event())
+    for _ in range(chunks):
+        await handler.handle_event(
+            AudioChunk(audio=b"\x00\x00" * 160, rate=RATE, width=2, channels=1).event()
+        )
+        # Let background work run, as it does between real chunks.
+        await asyncio.sleep(pace)
+
+    await handler.handle_event(AudioStop().event())
+
+
+# --- the prompt that reaches the transcriber ------------------------------
+
+
+async def test_without_a_token_the_configured_prompt_is_used():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=None, initial_prompt="Vocabulary:")
+
+    await _utterance(handler)
+
+    assert transcriber.prompt == "Vocabulary:"
+
+
+async def test_without_a_token_or_a_prompt_nothing_is_sent():
+    transcriber = FakeTranscriber()
+    await _utterance(_handler(transcriber))
+
+    assert transcriber.prompt is None
+
+
+async def test_home_assistant_names_reach_the_transcriber():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(FakeHass(_names("Ecobee", "Nanit"))))
+
+    await _utterance(handler)
+
+    assert transcriber.prompt == "Ecobee, Nanit."
+
+
+async def test_names_are_appended_to_the_configured_prompt():
+    transcriber = FakeTranscriber()
+    cache = _cache(FakeHass(_names("Ecobee")), prefix="Vocabulary:")
+    handler = _handler(transcriber, names=cache, initial_prompt="Vocabulary:")
+
+    await _utterance(handler)
+
+    assert transcriber.prompt == "Vocabulary: Ecobee."
+
+
+async def test_the_transcript_still_comes_back():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(FakeHass(_names("Ecobee"))))
+
+    await _utterance(handler)
+
+    assert handler.transcript == "fake transcript"
+
+
+# --- the AudioStart window ------------------------------------------------
+
+
+async def test_audio_start_starts_the_fetch_and_audio_stop_uses_it():
+    # Nothing is cached up front, so the names in the prompt can only have come
+    # from a fetch that began at AudioStart and landed by AudioStop.
+    hass = FakeHass(_names("Ecobee"))
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(hass))
+
+    await _utterance(handler)
+
+    assert hass.calls == 1
+    assert transcriber.prompt == "Ecobee."
+
+
+async def test_an_utterance_fetches_once_even_over_many_paced_chunks():
+    # The regression: a finished fetch is immediately due again, so without a
+    # per-utterance latch every chunk would start another one. Pacing matters --
+    # the fetch has to be able to finish mid-utterance to re-arm.
+    hass = FakeHass(_names("Ecobee"))
+    handler = _handler(FakeTranscriber(), names=_cache(hass))
+
+    await _utterance(handler, chunks=30, pace=0.001)
+
+    assert hass.calls == 1
+
+
+async def test_a_second_utterance_fetches_again():
+    hass = FakeHass(_names("Ecobee"))
+    handler = _handler(FakeTranscriber(), names=_cache(hass))
+
+    await _utterance(handler)
+    await _utterance(handler)
+
+    assert hass.calls == 2
+
+
+async def test_a_rename_between_utterances_is_picked_up():
+    hass = FakeHass(_names("Ecobee"))
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(hass))
+
+    await _utterance(handler)
+    assert transcriber.prompt == "Ecobee."
+
+    hass.context = _names("Ecobee", "Nanit")
+    await _utterance(handler)
+    assert transcriber.prompt == "Ecobee, Nanit."
+
+
+async def test_chunks_without_audio_start_still_refresh():
+    # Safety net for clients that skip AudioStart.
+    hass = FakeHass(_names("Ecobee"))
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(hass))
+
+    await handler.handle_event(Transcribe(language="en").event())
+    for _ in range(3):
+        await handler.handle_event(
+            AudioChunk(audio=b"\x00\x00" * 160, rate=RATE, width=2, channels=1).event()
+        )
+        await asyncio.sleep(0)
+
+    await handler.handle_event(AudioStop().event())
+
+    assert hass.calls == 1
+    assert transcriber.prompt == "Ecobee."
+
+
+# --- token budget --------------------------------------------------------
+
+
+async def test_the_budget_uses_the_models_own_tokenizer():
+    # 10 tokens per word: "Ecobee, Nanit." is 2 words -> 20, over a 15 budget,
+    # so only the first name fits.
+    transcriber = FakeTranscriber(tokens_per_word=10)
+    cache = _cache(FakeHass(_names("Ecobee", "Nanit")), max_tokens=15)
+    handler = _handler(transcriber, names=cache)
+
+    await _utterance(handler)
+
+    assert transcriber.prompt == "Ecobee."
+
+
+async def test_a_backend_without_a_tokenizer_still_gets_a_prompt():
+    # count_prompt_tokens returns None, so the character estimate is used.
+    transcriber = FakeTranscriber(tokens_per_word=None)
+    handler = _handler(transcriber, names=_cache(FakeHass(_names("Ecobee", "Nanit"))))
+
+    await _utterance(handler)
+
+    assert transcriber.prompt == "Ecobee, Nanit."
+
+
+# --- degradation ---------------------------------------------------------
+
+
+async def test_an_unreachable_home_assistant_still_transcribes():
+    hass = FakeHass(_names("Ecobee"))
+    hass.fail = True
+    transcriber = FakeTranscriber()
+    handler = _handler(
+        transcriber,
+        names=_cache(hass, prefix="Vocabulary:"),
+        initial_prompt="Vocabulary:",
+    )
+
+    await _utterance(handler)
+
+    assert handler.transcript == "fake transcript"
+    assert transcriber.prompt == "Vocabulary:"
+
+
+async def test_a_slow_fetch_does_not_stop_the_transcript():
+    hass = FakeHass(_names("Ecobee"), delay=5.0)
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(hass, wait_timeout=0.01))
+
+    await _utterance(handler)
+
+    assert handler.transcript == "fake transcript"
+    assert transcriber.prompt is None, "no names had arrived yet"
+
+
+async def test_audio_stop_with_no_audio_returns_an_empty_transcript():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, names=_cache(FakeHass(_names("Ecobee"))))
+
+    await handler.handle_event(Transcribe(language="en").event())
+    await handler.handle_event(AudioStop().event())
+
+    assert handler.transcript == ""
+    assert not transcriber.calls
+
+
+# --- streaming path ------------------------------------------------------
+
+
+async def test_a_streaming_session_gets_the_names_already_on_hand():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass)
+    await cache.refresh()
+
+    transcriber = FakeTranscriber(streaming=True)
+    handler = _handler(transcriber, names=cache)
+
+    await _utterance(handler)
+
+    assert transcriber.sessions
+    assert transcriber.sessions[0].initial_prompt == "Ecobee."
+    assert handler.transcript == "streamed transcript"
+
+
+async def test_a_streaming_session_does_not_wait_for_a_slow_fetch():
+    # The prompt is needed at the start of the audio, so there is nothing to
+    # wait for: the session opens with the prefix alone, immediately.
+    #
+    # The timing assert is the real check. Waiting would still end up with
+    # "Vocabulary:" once the timeout expired, so only elapsed time distinguishes
+    # "did not wait" from "waited and gave up".
+    hass = FakeHass(_names("Ecobee"), delay=30.0)
+    transcriber = FakeTranscriber(streaming=True)
+    handler = _handler(
+        transcriber,
+        names=_cache(hass, prefix="Vocabulary:", wait_timeout=30.0),
+        initial_prompt="Vocabulary:",
+    )
+
+    start = time.monotonic()
+    await _utterance(handler)
+    elapsed = time.monotonic() - start
+
+    assert transcriber.sessions[0].initial_prompt == "Vocabulary:"
+    assert elapsed < 1.0, f"streaming start blocked for {elapsed:.1f}s"

--- a/tests/test_hass_api.py
+++ b/tests/test_hass_api.py
@@ -1,0 +1,239 @@
+"""Tests for reading names out of Home Assistant.
+
+Runs against a real websocket server on localhost that speaks Home Assistant's
+protocol, so the auth handshake, the command/reply pairing, and the shape of the
+registry responses are all exercised for real -- only the data is fake.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("aiohttp")
+
+# pylint: disable=wrong-import-position
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestServer  # noqa: E402
+
+from wyoming_faster_whisper.hass_api import (  # noqa: E402
+    HomeAssistant,
+    HomeAssistantError,
+)
+
+TOKEN = "good-token"
+
+_EXPOSED = {
+    "exposed_entities": {
+        "light.office_lamp": {"conversation": True},
+        "sensor.ecobee": {"conversation": True},
+        "switch.old": {"conversation": True},
+        # Not exposed to conversation: not a possible voice target.
+        "light.secret": {"conversation": False},
+    }
+}
+
+_STATES = [
+    {"entity_id": "light.office_lamp", "attributes": {"friendly_name": "Office Lamp"}},
+    {"entity_id": "sensor.ecobee", "attributes": {"friendly_name": "Ecobee"}},
+    {"entity_id": "switch.old", "attributes": {"friendly_name": "Old Switch"}},
+    {"entity_id": "light.secret", "attributes": {"friendly_name": "Secret Light"}},
+]
+
+_ENTRIES = {
+    "light.office_lamp": {"aliases": ["Desk Lamp"], "disabled_by": None},
+    "sensor.ecobee": {"aliases": [], "disabled_by": None},
+    # Disabled entities are gone from the user's home in every practical sense.
+    "switch.old": {"aliases": ["Ancient Switch"], "disabled_by": "user"},
+}
+
+_AREAS = [
+    {"area_id": "office", "name": "Office", "aliases": ["Study"]},
+    {"area_id": "kitchen", "name": "Kitchen", "aliases": []},
+]
+
+_FLOORS = [{"floor_id": "upstairs", "name": "Upstairs", "aliases": ["Top Floor"]}]
+
+_RESULTS = {
+    "homeassistant/expose_entity/list": _EXPOSED,
+    "get_states": _STATES,
+    "config/entity_registry/get_entries": _ENTRIES,
+    "config/area_registry/list": _AREAS,
+    "config/floor_registry/list": _FLOORS,
+}
+
+
+def _app(results=None, fail_command=None) -> web.Application:
+    """A fake Home Assistant websocket API."""
+    results = _RESULTS if results is None else results
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        websocket = web.WebSocketResponse()
+        await websocket.prepare(request)
+
+        await websocket.send_json({"type": "auth_required", "ha_version": "2026.8.0"})
+        msg = json.loads((await websocket.receive()).data)
+        if (msg.get("type") != "auth") or (msg.get("access_token") != TOKEN):
+            await websocket.send_json({"type": "auth_invalid"})
+            return websocket
+
+        await websocket.send_json({"type": "auth_ok"})
+
+        async for raw in websocket:
+            msg = json.loads(raw.data)
+            msg_type = msg["type"]
+            if msg_type == fail_command:
+                await websocket.send_json(
+                    {
+                        "id": msg["id"],
+                        "type": "result",
+                        "success": False,
+                        "error": {"code": "unauthorized", "message": "nope"},
+                    }
+                )
+                continue
+
+            await websocket.send_json(
+                {
+                    "id": msg["id"],
+                    "type": "result",
+                    "success": True,
+                    "result": results[msg_type],
+                }
+            )
+
+        return websocket
+
+    app = web.Application()
+    app.router.add_get("/api/websocket", handler)
+    return app
+
+
+async def _client(app: web.Application, token: str = TOKEN):
+    """Start the fake server and return a client pointed at it, plus the server."""
+    server = TestServer(app)
+    await server.start_server()
+    hass = HomeAssistant(token, api_url=f"http://127.0.0.1:{server.port}/api")
+    return hass, server
+
+
+# --- happy path -----------------------------------------------------------
+
+
+async def test_reads_areas_floors_entities_and_aliases():
+    hass, server = await _client(_app())
+    try:
+        context = await hass.get_context()
+    finally:
+        await server.close()
+
+    assert context.areas == ["Office", "Study", "Kitchen"]
+    assert context.floors == ["Upstairs", "Top Floor"]
+    assert context.entities == ["Office Lamp", "Ecobee"]
+    assert context.aliases == ["Desk Lamp"]
+
+
+async def test_unexposed_entities_are_ignored():
+    hass, server = await _client(_app())
+    try:
+        context = await hass.get_context()
+    finally:
+        await server.close()
+
+    assert "Secret Light" not in context.all_names()
+
+
+async def test_disabled_entities_and_their_aliases_are_ignored():
+    hass, server = await _client(_app())
+    try:
+        context = await hass.get_context()
+    finally:
+        await server.close()
+
+    names = context.all_names()
+    assert "Old Switch" not in names
+    assert "Ancient Switch" not in names
+
+
+async def test_the_prompt_is_built_from_a_live_fetch():
+    hass, server = await _client(_app())
+    try:
+        context = await hass.get_context()
+    finally:
+        await server.close()
+
+    prompt = context.whisper_prompt(lambda text: len(text.split()), max_tokens=1000)
+    assert (
+        prompt
+        == "Office, Study, Kitchen, Upstairs, Top Floor, Office Lamp, Ecobee, Desk Lamp."
+    )
+
+
+async def test_an_empty_home_yields_no_names():
+    empty = {
+        "homeassistant/expose_entity/list": {"exposed_entities": {}},
+        "get_states": [],
+        "config/area_registry/list": [],
+        "config/floor_registry/list": [],
+    }
+    hass, server = await _client(_app(results=empty))
+    try:
+        context = await hass.get_context()
+    finally:
+        await server.close()
+
+    assert not context
+
+
+# --- failures -------------------------------------------------------------
+
+
+async def test_a_bad_token_raises():
+    hass, server = await _client(_app(), token="wrong-token")
+    try:
+        with pytest.raises(HomeAssistantError):
+            await hass.get_context()
+    finally:
+        await server.close()
+
+
+async def test_a_refused_command_raises():
+    hass, server = await _client(_app(fail_command="get_states"))
+    try:
+        with pytest.raises(HomeAssistantError):
+            await hass.get_context()
+    finally:
+        await server.close()
+
+
+async def test_an_unreachable_home_assistant_raises():
+    # Nothing is listening on this port.
+    hass = HomeAssistant(TOKEN, api_url="http://127.0.0.1:1/api", timeout=2.0)
+    with pytest.raises(HomeAssistantError):
+        await hass.get_context()
+
+
+# --- url handling ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("api_url", "expected"),
+    [
+        (
+            "http://homeassistant.local:8123/api",
+            "ws://homeassistant.local:8123/api/websocket",
+        ),
+        ("https://ha.example.com/api", "wss://ha.example.com/api/websocket"),
+        # A trailing slash must not double up.
+        (
+            "http://homeassistant.local:8123/api/",
+            "ws://homeassistant.local:8123/api/websocket",
+        ),
+    ],
+)
+def test_websocket_url_is_derived_from_the_api_url(api_url, expected):
+    assert HomeAssistant(TOKEN, api_url=api_url).websocket_api_url == expected
+
+
+def test_a_non_http_url_is_rejected():
+    with pytest.raises(ValueError):
+        HomeAssistant(TOKEN, api_url="ftp://homeassistant.local/api")

--- a/tests/test_name_cache.py
+++ b/tests/test_name_cache.py
@@ -1,0 +1,255 @@
+"""Tests for the background refresh of Home Assistant's names.
+
+The Home Assistant client is faked, so nothing here touches the network. What is
+being pinned down is the degradation behavior: a refresh that fails, or that is
+still running when the audio stops, must cost freshness and never a transcript.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("aiohttp")
+
+# pylint: disable=wrong-import-position
+from wyoming.info import Info  # noqa: E402
+
+from wyoming_faster_whisper.dispatch_handler import DispatchEventHandler  # noqa: E402
+from wyoming_faster_whisper.hass_api import HomeAssistantError  # noqa: E402
+from wyoming_faster_whisper.name_cache import HassNameCache  # noqa: E402
+from wyoming_faster_whisper.vocabulary import RecognitionContext  # noqa: E402
+
+
+class FakeHass:
+    """Stands in for HomeAssistant, with scriptable results and delay."""
+
+    def __init__(self, context=None, delay=0.0):
+        self.context = context if context is not None else RecognitionContext()
+        self.delay = delay
+        self.fail = False
+        self.calls = 0
+
+    async def get_context(self) -> RecognitionContext:
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+
+        if self.fail:
+            raise HomeAssistantError("unreachable")
+
+        return self.context
+
+
+def _cache(hass, **kwargs) -> HassNameCache:
+    kwargs.setdefault("max_tokens", 1000)
+    return HassNameCache(hass, **kwargs)
+
+
+def _names(*entities) -> RecognitionContext:
+    return RecognitionContext(entities=list(entities))
+
+
+# --- prompt ---------------------------------------------------------------
+
+
+async def test_prompt_is_the_prefix_alone_before_any_fetch():
+    cache = _cache(FakeHass(), prefix="Vocabulary:")
+    assert await cache.initial_prompt() == "Vocabulary:"
+
+
+async def test_prompt_is_none_before_any_fetch_without_a_prefix():
+    assert await _cache(FakeHass()).initial_prompt() is None
+
+
+async def test_fetched_names_reach_the_prompt():
+    cache = _cache(FakeHass(_names("Ecobee", "Nanit")), prefix="Vocabulary:")
+    assert await cache.refresh()
+    assert await cache.initial_prompt() == "Vocabulary: Ecobee, Nanit."
+
+
+# --- refresh scheduling ---------------------------------------------------
+
+
+async def test_scheduled_refresh_lands_before_the_prompt_is_needed():
+    cache = _cache(FakeHass(_names("Ecobee")))
+    cache.schedule_refresh()
+
+    # initial_prompt waits for the in-flight fetch, as it does at AudioStop.
+    assert await cache.initial_prompt() == "Ecobee."
+
+
+async def test_concurrent_schedules_collapse_onto_one_fetch():
+    hass = FakeHass(_names("Ecobee"), delay=0.05)
+    cache = _cache(hass)
+
+    cache.schedule_refresh()
+    cache.schedule_refresh()
+    cache.schedule_refresh()
+    await cache.initial_prompt()
+
+    assert hass.calls == 1
+
+
+async def test_refresh_seconds_throttles_repeat_fetches():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass, refresh_seconds=60.0)
+
+    cache.schedule_refresh()
+    await cache.initial_prompt()
+    cache.schedule_refresh()
+    await cache.initial_prompt()
+
+    assert hass.calls == 1
+
+
+async def test_zero_refresh_seconds_fetches_every_utterance():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass, refresh_seconds=0.0)
+
+    for _ in range(3):
+        cache.schedule_refresh()
+        await cache.initial_prompt()
+
+    assert hass.calls == 3
+
+
+# --- degradation ----------------------------------------------------------
+
+
+async def test_a_failed_fetch_leaves_no_names_but_keeps_the_prefix():
+    hass = FakeHass()
+    hass.fail = True
+    cache = _cache(hass, prefix="Vocabulary:")
+
+    assert not await cache.refresh()
+    assert await cache.initial_prompt() == "Vocabulary:"
+
+
+async def test_a_failed_refresh_keeps_the_previous_names():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass)
+    await cache.refresh()
+
+    hass.fail = True
+    cache.schedule_refresh()
+
+    assert await cache.initial_prompt() == "Ecobee."
+
+
+async def test_a_slow_refresh_does_not_hold_up_transcription():
+    hass = FakeHass(_names("Ecobee"), delay=0.02)
+    cache = _cache(hass)
+    await cache.refresh()
+
+    hass.context = _names("Ecobee", "Nanit")
+    hass.delay = 5.0
+    cache.schedule_refresh()
+
+    # The slow fetch is abandoned for this utterance; the old names are used.
+    assert await cache.initial_prompt() == "Ecobee."
+
+
+async def test_a_refresh_that_timed_out_is_not_cancelled():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass, wait_timeout=0.01)
+    await cache.refresh()
+
+    hass.context = _names("Ecobee", "Nanit")
+    hass.delay = 0.1
+    cache.schedule_refresh()
+
+    # Times out and falls back...
+    assert await cache.initial_prompt() == "Ecobee."
+
+    # ...but the fetch kept running, so the next utterance has the new names.
+    await asyncio.sleep(0.2)
+    assert await cache.initial_prompt(wait=False) == "Ecobee, Nanit."
+
+
+async def test_streaming_path_does_not_wait():
+    hass = FakeHass(_names("Ecobee"), delay=5.0)
+    cache = _cache(hass, prefix="Vocabulary:")
+    cache.schedule_refresh()
+
+    # wait=False returns immediately with whatever is on hand (nothing yet).
+    assert await cache.initial_prompt(wait=False) == "Vocabulary:"
+
+
+# --- snapshot reuse -------------------------------------------------------
+
+
+async def test_unchanged_names_keep_the_cached_prompt():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass)
+    await cache.refresh()
+    before = cache._context  # pylint: disable=protected-access
+
+    # A fresh but equal context arrives.
+    hass.context = _names("Ecobee")
+    await cache.refresh()
+
+    assert cache._context is before  # pylint: disable=protected-access
+
+
+async def test_renamed_entity_replaces_the_snapshot():
+    hass = FakeHass(_names("Ecobee"))
+    cache = _cache(hass)
+    await cache.refresh()
+
+    hass.context = _names("Ecobee", "Nanit")
+    await cache.refresh()
+
+    assert await cache.initial_prompt(wait=False) == "Ecobee, Nanit."
+
+
+# --- once per utterance ---------------------------------------------------
+
+
+def _handler(cache) -> DispatchEventHandler:
+    """A handler with no I/O: only the name-refresh latch is exercised."""
+    return DispatchEventHandler(Info(), None, cache, None, None)
+
+
+async def test_an_utterance_asks_for_exactly_one_refresh():
+    # A finished fetch is immediately due again at refresh_seconds=0, so without
+    # a per-utterance latch every audio chunk would start another one.
+    hass = FakeHass(_names("Ecobee"))
+    handler = _handler(_cache(hass))
+
+    for _ in range(50):
+        # Stands in for AudioStart followed by a stream of AudioChunks.
+        handler._refresh_names()  # pylint: disable=protected-access
+        await asyncio.sleep(0)
+
+    await asyncio.sleep(0.05)
+    assert hass.calls == 1
+
+
+async def test_the_next_utterance_refreshes_again():
+    hass = FakeHass(_names("Ecobee"))
+    handler = _handler(_cache(hass))
+
+    for _ in range(2):
+        handler._refresh_names()  # pylint: disable=protected-access
+        await asyncio.sleep(0.01)
+        handler._reset()  # pylint: disable=protected-access
+
+    assert hass.calls == 2
+
+
+async def test_no_refresh_without_a_cache():
+    # Nothing to latch, and nothing to crash on.
+    _handler(None)._refresh_names()  # pylint: disable=protected-access
+
+
+async def test_has_names_reflects_whether_a_fetch_succeeded():
+    hass = FakeHass(_names("Ecobee"))
+    hass.fail = True
+    cache = _cache(hass)
+
+    await cache.refresh()
+    assert not cache.has_names
+
+    hass.fail = False
+    await cache.refresh()
+    assert cache.has_names

--- a/tests/test_qwen3_asr.py
+++ b/tests/test_qwen3_asr.py
@@ -5,6 +5,9 @@ template the decoder is prompted with, and the mel front-end. Skipped when
 onnxruntime is not installed (the handler imports it at module scope).
 """
 
+import json
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -14,11 +17,14 @@ qwen3_asr_handler = pytest.importorskip(
 )
 
 _build_prompt_ids = qwen3_asr_handler.Qwen3AsrTranscriber._build_prompt_ids
+_causal_mask = qwen3_asr_handler._causal_mask
 _log_mel_spectrogram = qwen3_asr_handler._log_mel_spectrogram
 _mel_filterbank = qwen3_asr_handler._mel_filterbank
+_system_ids = qwen3_asr_handler._system_ids
 qwen3_asr_language = qwen3_asr_handler.qwen3_asr_language
 
 _AUDIO_PAD = qwen3_asr_handler._AUDIO_PAD
+_BLOCKED = qwen3_asr_handler._MASK_BLOCKED
 
 
 # --- language normalization ------------------------------------------------
@@ -71,6 +77,164 @@ def test_forced_language_suffix_goes_after_the_assistant_turn() -> None:
     ids = _build_prompt_ids(None, 1, [], language_ids)
     assert ids[-2:] == language_ids
     assert ids[-3] == 198  # newline closing "<|im_start|>assistant\n"
+
+
+# --- merged decoder: the cached span ---------------------------------------
+
+
+def test_system_turn_is_the_prompts_prefix() -> None:
+    """The cached span must be a literal prefix of the prompt, or reusing its KV
+    would silently attend to the wrong positions."""
+    context = [1111, 2222]
+    ids = _build_prompt_ids(None, 3, context, [])
+    system = _system_ids(context)
+    assert ids[: len(system)] == system
+
+
+def test_system_turn_holds_the_context_and_no_audio() -> None:
+    system = _system_ids([1111, 2222])
+    assert system == [151644, 8948, 198, 1111, 2222, 151645, 198]
+    # Nothing about the audio may be inside the cached span.
+    assert _AUDIO_PAD not in system
+
+
+def test_system_turn_length_tracks_the_context() -> None:
+    assert len(_system_ids([])) == 5
+    assert len(_system_ids([1, 2, 3])) == 8
+
+
+# --- merged decoder: attention mask ----------------------------------------
+
+
+def test_mask_is_causal_when_there_is_no_cache() -> None:
+    mask = _causal_mask(3, 0)
+    assert mask.shape == (1, 1, 3, 3)
+    # Row i may attend to columns <= i.
+    assert (mask[0, 0] == 0).tolist() == [
+        [True, False, False],
+        [True, True, False],
+        [True, True, True],
+    ]
+
+
+def test_mask_allows_every_cached_position() -> None:
+    mask = _causal_mask(2, 4)
+    assert mask.shape == (1, 1, 2, 6)
+    # The four cached positions are open to both new tokens...
+    assert (mask[0, 0, :, :4] == 0).all()
+    # ...and the new tokens stay causal among themselves.
+    assert mask[0, 0, 0, 4] == 0
+    assert mask[0, 0, 0, 5] == _BLOCKED
+    assert mask[0, 0, 1, 4] == 0
+    assert mask[0, 0, 1, 5] == 0
+
+
+def test_single_token_step_attends_to_everything() -> None:
+    mask = _causal_mask(1, 7)
+    assert mask.shape == (1, 1, 1, 8)
+    assert (mask == 0).all()
+
+
+def test_mask_blocks_with_a_large_negative_and_is_float32() -> None:
+    mask = _causal_mask(2, 0)
+    assert mask.dtype == np.float32
+    assert mask[0, 0, 0, 1] == _BLOCKED
+    assert _BLOCKED < -1e30
+
+
+# --- model file selection --------------------------------------------------
+
+
+class _FakeSession:
+    """Enough of an ORT session to get through the constructor."""
+
+    def __init__(self, path, **kwargs) -> None:
+        self.path = str(path)
+
+    def get_inputs(self):
+        return [SimpleNamespace(name="mel")]
+
+    def get_outputs(self):
+        # logits, then present_keys/present_values shaped
+        # [num_layers, batch, kv_heads, seq, head_dim] with the batch and
+        # sequence dims symbolic, as the real export has them.
+        kv = SimpleNamespace(name="present_keys", shape=[4, "batch", 2, "seq", 8])
+        return [SimpleNamespace(name="logits", shape=["batch", "q", 99]), kv, kv]
+
+
+def _fake_model_dir(tmp_path, merged: bool):
+    """A model directory with the right filenames and no real weights."""
+    path = tmp_path / ("merged" if merged else "split")
+    path.mkdir()
+    (path / "config.json").write_text(json.dumps({"decoder": {"hidden_size": 8}}))
+    (path / "tokenizer.json").write_text("{}")
+    (path / "embed_tokens.bin").write_bytes(b"")
+    names = ["encoder.int4.onnx"]
+    names += (
+        ["decoder_merged.int4.onnx"]
+        if merged
+        else ["decoder_init.int4.onnx", "decoder_step.int4.onnx"]
+    )
+    for name in names:
+        (path / name).write_bytes(b"")
+    return path
+
+
+@pytest.fixture(name="stub_runtime")
+def stub_runtime_fixture(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_handler.ort, "InferenceSession", _FakeSession)
+    monkeypatch.setattr(
+        qwen3_asr_handler, "Tokenizer", SimpleNamespace(from_file=lambda path: object())
+    )
+    monkeypatch.setattr(
+        qwen3_asr_handler.np,
+        "fromfile",
+        lambda *args, **kwargs: np.zeros(16, dtype=np.float16),
+    )
+
+
+def test_merged_decoder_is_preferred_when_present(tmp_path, stub_runtime) -> None:
+    model = qwen3_asr_handler.Qwen3AsrTranscriber(
+        str(_fake_model_dir(tmp_path, merged=True)), str(tmp_path)
+    )
+    assert model._merged is not None
+    assert model._decoder_init is None
+    assert model._decoder_step is None
+
+
+def test_split_decoder_is_used_when_merged_is_absent(tmp_path, stub_runtime) -> None:
+    model = qwen3_asr_handler.Qwen3AsrTranscriber(
+        str(_fake_model_dir(tmp_path, merged=False)), str(tmp_path)
+    )
+    assert model._merged is None
+    assert model._decoder_init is not None
+    assert model._decoder_step is not None
+
+
+def test_empty_kv_is_shaped_from_the_graph(tmp_path, stub_runtime) -> None:
+    # Taken from present_keys so the cache does not depend on config.json.
+    model = qwen3_asr_handler.Qwen3AsrTranscriber(
+        str(_fake_model_dir(tmp_path, merged=True)), str(tmp_path)
+    )
+    assert model._empty_kv.shape == (4, 1, 2, 0, 8)
+    assert model._empty_kv.dtype == np.float32
+
+
+def test_prefix_cache_starts_empty(tmp_path, stub_runtime) -> None:
+    model = qwen3_asr_handler.Qwen3AsrTranscriber(
+        str(_fake_model_dir(tmp_path, merged=True)), str(tmp_path)
+    )
+    assert model._prefix_key is None
+    assert model._prefix_kv is None
+
+
+def test_allow_patterns_cover_both_decoder_layouts() -> None:
+    patterns = set(qwen3_asr_handler._ALLOW_PATTERNS)
+    assert qwen3_asr_handler._MERGED_DECODER in patterns
+    assert "decoder_merged.int4.onnx.data" in patterns
+    # The split layout must still be downloadable.
+    assert {"decoder_init.int4.onnx", "decoder_step.int4.onnx"} <= patterns
+    assert "decoder_weights.int4.data" in patterns
 
 
 # --- mel front-end ---------------------------------------------------------

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,0 +1,207 @@
+"""Tests for the biasing prompt built from Home Assistant's names.
+
+Dependency-free: the token counter is injected, so no model or tokenizer is
+needed and the budget is exact and predictable.
+"""
+
+import pytest
+
+from wyoming_faster_whisper.vocabulary import (
+    RecognitionContext,
+    clean_names,
+    estimate_tokens,
+)
+
+
+def _words(text: str) -> int:
+    """Stand-in tokenizer: one token per whitespace-separated word."""
+    return len(text.split())
+
+
+def _context(**kwargs) -> RecognitionContext:
+    return RecognitionContext(**kwargs)
+
+
+# --- clean_names ----------------------------------------------------------
+
+
+def test_clean_names_strips_and_collapses_whitespace():
+    assert clean_names(["  Living   Room  "]) == ["Living Room"]
+
+
+def test_clean_names_dedupes_case_insensitively_keeping_first_spelling():
+    assert clean_names(["Kitchen"], ["kitchen", "Office"]) == ["Kitchen", "Office"]
+
+
+def test_clean_names_drops_empty_and_non_strings():
+    assert clean_names(["", "   ", None, 5, "Office"]) == ["Office"]
+
+
+def test_clean_names_tolerates_none_groups():
+    assert clean_names(None, ["Office"]) == ["Office"]
+
+
+# --- priority order ------------------------------------------------------
+
+
+def test_all_names_is_areas_then_floors_then_entities_then_aliases():
+    context = _context(
+        areas=["Office"],
+        floors=["Upstairs"],
+        entities=["Ecobee"],
+        aliases=["Thermostat"],
+    )
+    assert context.all_names() == ["Office", "Upstairs", "Ecobee", "Thermostat"]
+
+
+def test_names_repeated_across_buckets_are_only_paid_for_once():
+    context = _context(areas=["Office"], entities=["office", "Ecobee"])
+    assert context.all_names() == ["Office", "Ecobee"]
+
+
+def test_budget_keeps_higher_priority_names_and_drops_the_rest():
+    context = _context(areas=["Office"], entities=["Ecobee", "Nanit"])
+
+    # Three words fits "Office, Ecobee," plus nothing more.
+    prompt = context.whisper_prompt(_words, max_tokens=2)
+    assert prompt == "Office, Ecobee."
+
+
+def test_truncation_is_deterministic():
+    context = _context(entities=[f"Name{i}" for i in range(50)])
+    first = context.whisper_prompt(_words, max_tokens=5)
+    second = _context(entities=[f"Name{i}" for i in range(50)]).whisper_prompt(
+        _words, max_tokens=5
+    )
+    assert first == second
+
+
+# --- prompt rendering ----------------------------------------------------
+
+
+def test_prompt_is_comma_joined_and_ends_with_a_period():
+    context = _context(areas=["Office", "Kitchen"])
+    assert context.whisper_prompt(_words, max_tokens=100) == "Office, Kitchen."
+
+
+def test_prefix_is_kept_verbatim_when_it_ends_in_punctuation():
+    context = _context(entities=["Ecobee"])
+    prompt = context.whisper_prompt(_words, max_tokens=100, prefix="Vocabulary:")
+    assert prompt == "Vocabulary: Ecobee."
+
+
+def test_prefix_without_punctuation_becomes_its_own_sentence():
+    context = _context(entities=["Ecobee"])
+    prompt = context.whisper_prompt(_words, max_tokens=100, prefix="  Smart home  ")
+    assert prompt == "Smart home. Ecobee."
+
+
+def test_prefix_counts_against_the_budget():
+    context = _context(entities=["Ecobee", "Nanit"])
+
+    # "Vocabulary: Ecobee." is two words; adding Nanit would make three.
+    prompt = context.whisper_prompt(_words, max_tokens=2, prefix="Vocabulary:")
+    assert prompt == "Vocabulary: Ecobee."
+
+
+def test_prefix_survives_a_budget_too_small_for_any_name():
+    context = _context(entities=["Ecobee"])
+    prompt = context.whisper_prompt(_words, max_tokens=1, prefix="Vocabulary:")
+    assert prompt == "Vocabulary:"
+
+
+def test_no_names_and_no_prefix_gives_no_prompt():
+    assert _context().whisper_prompt(_words, max_tokens=100) is None
+
+
+def test_no_names_falls_back_to_the_prefix_alone():
+    prompt = _context().whisper_prompt(_words, max_tokens=100, prefix="Vocabulary:")
+    assert prompt == "Vocabulary:"
+
+
+# --- caching -------------------------------------------------------------
+
+
+def test_prompt_is_built_once_per_budget_and_tokenizer():
+    calls = []
+
+    def counting(text: str) -> int:
+        calls.append(text)
+        return _words(text)
+
+    context = _context(entities=["Ecobee", "Nanit"])
+    first = context.whisper_prompt(counting, max_tokens=100)
+    used = len(calls)
+    second = context.whisper_prompt(counting, max_tokens=100)
+
+    assert first == second
+    assert len(calls) == used, "cached prompt should not re-tokenize"
+
+
+def test_a_different_tokenizer_rebuilds_the_prompt():
+    context = _context(entities=["Ecobee"])
+    context.whisper_prompt(_words, max_tokens=100, tokenizer_key="a")
+
+    calls = []
+
+    def counting(text: str) -> int:
+        calls.append(text)
+        return _words(text)
+
+    context.whisper_prompt(counting, max_tokens=100, tokenizer_key="b")
+    assert calls, "a new tokenizer must not reuse another's budget"
+
+
+def test_equality_ignores_the_prompt_cache():
+    left = _context(entities=["Ecobee"])
+    right = _context(entities=["Ecobee"])
+    left.whisper_prompt(_words, max_tokens=100)
+
+    assert left == right, "a built prompt must not make snapshots unequal"
+
+
+# --- misc ----------------------------------------------------------------
+
+
+def test_context_is_falsey_when_empty():
+    assert not _context()
+    assert _context(aliases=["Thermostat"])
+
+
+@pytest.mark.parametrize("text", ["", "a", "Ecobee", "Living Room Lamp" * 20])
+def test_estimate_tokens_is_positive(text):
+    assert estimate_tokens(text) >= 1
+
+
+def test_estimate_tokens_over_counts_a_realistic_prompt():
+    """The fallback must never come in under the real count.
+
+    Under-counting overflows Whisper's 223-token cap and the prompt is silently
+    truncated. The token figure below was measured with Whisper's own BPE
+    (faster-whisper 1.2.1, rhasspy/faster-whisper-tiny-int8).
+    """
+    names = [
+        "Office",
+        "Kitchen",
+        "Living Room",
+        "Upstairs",
+        "Main Floor",
+        "Ecobee",
+        "Nanit",
+        "Office Lamp",
+        "Desk Lamp",
+        "Thermostat",
+        "Bedroom Blinds",
+        "Aqara Switch",
+        "Sonos Arc",
+        "Nest Hub Max",
+        "Roborock S7",
+        "LIFX Strip",
+        "Wyze Cam",
+        "Shelly Plug",
+        "Zooz ZEN32",
+    ]
+    prompt = ", ".join(names) + "."
+    real_tokens = 76  # 217 characters, so 2.85 per token
+
+    assert estimate_tokens(prompt) >= real_tokens

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -5,16 +5,27 @@ import logging
 import platform
 import re
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import faster_whisper
 from wyoming.info import AsrModel, AsrProgram, Attribution, Info
 from wyoming.server import AsyncServer, AsyncTcpServer
 
 from . import __version__
-from .const import AUTO_LANGUAGE, AUTO_MODEL, PARAKEET_LANGUAGES, SttLibrary
+from .const import (
+    AUTO_LANGUAGE,
+    AUTO_MODEL,
+    HASS_API_URL,
+    PARAKEET_LANGUAGES,
+    SttLibrary,
+)
 from .dispatch_handler import DispatchEventHandler
 from .models import ModelLoader
+from .vocabulary import DEFAULT_PROMPT_MAX_TOKENS
+
+if TYPE_CHECKING:
+    # Imported for typing only: aiohttp is an optional extra.
+    from .name_cache import HassNameCache
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,6 +150,38 @@ async def main() -> None:
         action="store_true",
         help="Don't check HuggingFace hub for updates every time",
     )
+    # Home Assistant name biasing (extra: hass)
+    parser.add_argument(
+        "--hass-token",
+        help="Long-lived access token for Home Assistant. Enables biasing toward "
+        "the names of exposed entities, areas, and floors (extra: hass)",
+    )
+    parser.add_argument(
+        "--hass-api",
+        default=HASS_API_URL,
+        help=f"URL of the Home Assistant API (default: {HASS_API_URL})",
+    )
+    parser.add_argument(
+        "--hass-refresh-seconds",
+        type=float,
+        default=0.0,
+        help="Minimum seconds between name refreshes (default: 0, refresh on "
+        "every utterance)",
+    )
+    parser.add_argument(
+        "--hass-prompt-max-tokens",
+        type=int,
+        default=DEFAULT_PROMPT_MAX_TOKENS,
+        help="Token budget for names in the prompt "
+        f"(default: {DEFAULT_PROMPT_MAX_TOKENS}, max useful: 223 for Whisper)",
+    )
+    parser.add_argument(
+        "--hass-prompt-timeout",
+        type=float,
+        default=1.0,
+        help="Seconds to wait for an unfinished name refresh before transcribing "
+        "with the previous names (default: 1.0)",
+    )
     #
     parser.add_argument("--debug", action="store_true", help="Log DEBUG messages")
     parser.add_argument(
@@ -252,6 +295,8 @@ async def main() -> None:
     _LOGGER.debug("Pre-loading transcriber")
     await loader.load_transcriber()
 
+    names = await _load_names(args)
+
     server = AsyncServer.from_uri(args.uri)
 
     if args.zeroconf:
@@ -273,8 +318,48 @@ async def main() -> None:
             DispatchEventHandler,
             wyoming_info,
             loader,
+            names,
         )
     )
+
+
+# -----------------------------------------------------------------------------
+
+
+async def _load_names(args: argparse.Namespace) -> Optional["HassNameCache"]:
+    """Set up biasing toward Home Assistant's names, if a token was given."""
+    if not args.hass_token:
+        return None
+
+    try:
+        from .hass_api import HomeAssistant
+        from .name_cache import HassNameCache
+    except ImportError as exc:
+        raise ImportError(
+            "--hass-token requires the 'hass' extra: "
+            "pip install 'wyoming-faster-whisper[hass]'"
+        ) from exc
+
+    names = HassNameCache(
+        HomeAssistant(args.hass_token, api_url=args.hass_api),
+        prefix=args.initial_prompt,
+        max_tokens=args.hass_prompt_max_tokens,
+        refresh_seconds=args.hass_refresh_seconds,
+        wait_timeout=args.hass_prompt_timeout,
+    )
+
+    # Fetch once now so the first utterance is biased too. Best effort: Home
+    # Assistant may still be starting up, and that must not stop this server
+    # from serving. Every utterance retries.
+    if await names.refresh():
+        _LOGGER.info("Biasing toward names from %s", args.hass_api)
+    else:
+        _LOGGER.warning(
+            "No names loaded from %s yet; will retry on each utterance",
+            args.hass_api,
+        )
+
+    return names
 
 
 # -----------------------------------------------------------------------------

--- a/wyoming_faster_whisper/const.py
+++ b/wyoming_faster_whisper/const.py
@@ -21,6 +21,9 @@ class SttLibrary(str, Enum):
 AUTO_LANGUAGE = "auto"
 AUTO_MODEL = "auto"
 
+# Where to look for Home Assistant when biasing toward its names.
+HASS_API_URL = "http://homeassistant.local:8123/api"
+
 # SenseVoice (FunASR) can be told to decode these languages explicitly;
 # otherwise it auto-detects. Maps the locale-style codes that Home Assistant /
 # intent-sentences use (e.g. "zh-CN") onto the base SenseVoice language.
@@ -85,6 +88,15 @@ class Transcriber(ABC):
         initial_prompt: Optional[str] = None,
     ) -> str:
         pass
+
+    def count_prompt_tokens(self, text: str) -> Optional[int]:
+        """Count the tokens ``text`` would use as an initial_prompt.
+
+        Returns None when this backend has no tokenizer to ask, in which case
+        callers fall back to an estimate. Used to fit as many entity names as
+        possible into the prompt without crossing the model's context limit.
+        """
+        return None
 
     @property
     def supports_streaming(self) -> bool:

--- a/wyoming_faster_whisper/dispatch_handler.py
+++ b/wyoming_faster_whisper/dispatch_handler.py
@@ -4,11 +4,12 @@ import asyncio
 import logging
 import os
 import tempfile
+import time
 import wave
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from wyoming.asr import Transcribe, Transcript
-from wyoming.audio import AudioChunk, AudioChunkConverter, AudioStop
+from wyoming.audio import AudioChunk, AudioChunkConverter, AudioStart, AudioStop
 from wyoming.event import Event
 from wyoming.info import Describe, Info
 from wyoming.server import AsyncEventHandler
@@ -16,6 +17,11 @@ from wyoming.server import AsyncEventHandler
 from .const import StreamingSession, Transcriber
 from .models import ModelLoader
 from .vad import clip_wav_to_speech
+
+if TYPE_CHECKING:
+    # Imported for typing only: the name cache pulls in aiohttp, which is an
+    # optional extra.
+    from .name_cache import HassNameCache
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +33,7 @@ class DispatchEventHandler(AsyncEventHandler):
         self,
         wyoming_info: Info,
         loader: ModelLoader,
+        names: Optional["HassNameCache"],
         *args,
         **kwargs,
     ) -> None:
@@ -35,6 +42,7 @@ class DispatchEventHandler(AsyncEventHandler):
         self.wyoming_info_event = wyoming_info.event()
 
         self._loader = loader
+        self._names = names
         self._transcriber: Optional[Transcriber] = None
         self._transcriber_future: Optional[asyncio.Future] = None
         self._language: Optional[str] = None
@@ -55,10 +63,25 @@ class DispatchEventHandler(AsyncEventHandler):
         self._session: Optional[StreamingSession] = None
         self._pending_audio: List[bytes] = []
 
+        # Whether this utterance already asked for a name refresh.
+        self._refreshed_names = False
+
     async def handle_event(self, event: Event) -> bool:
+        if AudioStart.is_type(event.type):
+            # Start refreshing Home Assistant's names now. The speaker is still
+            # talking, so the fetch has the length of their command to finish in
+            # and costs no latency at all.
+            self._refresh_names()
+            return True
+
         if AudioChunk.is_type(event.type):
             chunk = self._audio_converter.convert(AudioChunk.from_event(event))
             self._got_audio = True
+
+            # Safety net for clients that send audio without AudioStart. Calls
+            # after the first are cheap: a refresh already in flight is not
+            # started again.
+            self._refresh_names()
 
             if (self._transcriber is None) and (self._transcriber_future is None):
                 # Load the transcriber in the background.
@@ -89,6 +112,7 @@ class DispatchEventHandler(AsyncEventHandler):
 
         if AudioStop.is_type(event.type):
             _LOGGER.debug("Audio stopped")
+            start_time = time.monotonic()
 
             # No audio was received before AudioStop — return empty transcript.
             # This happens when HA sends AudioStop without any AudioChunk
@@ -141,13 +165,14 @@ class DispatchEventHandler(AsyncEventHandler):
                     wav_path,
                     self._language,
                     beam_size=self._loader.beam_size,
-                    initial_prompt=self._loader.initial_prompt,
+                    initial_prompt=await self._initial_prompt(),
                 )
 
+            end_time = time.monotonic()
             _LOGGER.info(text)
 
             await self.write_event(Transcript(text=text).event())
-            _LOGGER.debug("Completed request")
+            _LOGGER.debug("Completed request in %s second(s)", end_time - start_time)
 
             self._reset()
 
@@ -167,6 +192,32 @@ class DispatchEventHandler(AsyncEventHandler):
 
         return True
 
+    def _refresh_names(self) -> None:
+        """Kick off one background refresh of Home Assistant's names per utterance.
+
+        Called from both AudioStart and every AudioChunk, so it has to latch: a
+        finished fetch is immediately due again (--hass-refresh-seconds defaults
+        to 0), and without the latch every chunk would start another one.
+        """
+        if (self._names is None) or self._refreshed_names:
+            return
+
+        self._refreshed_names = True
+        self._names.schedule_refresh()
+
+    async def _initial_prompt(self, wait: bool = True) -> Optional[str]:
+        """The prompt to bias this utterance with.
+
+        Without --hass-token this is just the configured --initial-prompt; with
+        it, that prefix plus as many of Home Assistant's names as fit.
+        """
+        if self._names is None:
+            return self._loader.initial_prompt
+
+        prompt = await self._names.initial_prompt(self._transcriber, wait=wait)
+        _LOGGER.debug("Initial prompt: %s", prompt)
+        return prompt
+
     def _resolve_transcriber(self) -> None:
         """Promote the background-loaded transcriber if it's ready (no blocking)."""
         if self._transcriber is not None:
@@ -185,7 +236,9 @@ class DispatchEventHandler(AsyncEventHandler):
             self._session = self._transcriber.start_stream(
                 self._language,
                 beam_size=self._loader.beam_size,
-                initial_prompt=self._loader.initial_prompt,
+                # A streaming session needs its prompt before the audio ends, so
+                # there is nothing to wait for: use the names already on hand.
+                initial_prompt=await self._initial_prompt(wait=False),
             )
             if self._pending_audio:
                 # Replay audio buffered before the transcriber was ready.
@@ -222,3 +275,4 @@ class DispatchEventHandler(AsyncEventHandler):
         self._is_streaming = None
         self._session = None
         self._pending_audio = []
+        self._refreshed_names = False

--- a/wyoming_faster_whisper/faster_whisper_handler.py
+++ b/wyoming_faster_whisper/faster_whisper_handler.py
@@ -36,6 +36,13 @@ class FasterWhisperTranscriber(Transcriber):
             cpu_threads=cpu_threads,
         )
 
+    def count_prompt_tokens(self, text: str) -> Optional[int]:
+        tokenizer = getattr(self.model, "hf_tokenizer", None)
+        if tokenizer is None:
+            return None
+
+        return len(tokenizer.encode(text, add_special_tokens=False).ids)
+
     def transcribe(
         self,
         wav_path: Union[str, Path],

--- a/wyoming_faster_whisper/hass_api.py
+++ b/wyoming_faster_whisper/hass_api.py
@@ -1,0 +1,205 @@
+"""Read the names in a Home Assistant install over the websocket API.
+
+Read-only and recognition-only: this fetches the names a speaker can actually
+say -- exposed entities, the areas and floors they live in -- and never calls a
+service or handles an intent. The result is a
+[RecognitionContext](vocabulary.py) that biases speech-to-text.
+
+Only *conversation-exposed* entities are collected. Every entity in the house
+would put hundreds of names the speaker cannot mean into a prompt with room for
+a few dozen, crowding out the ones they can.
+
+Requires the ``hass`` extra (aiohttp).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Coroutine, Dict, List, Set
+from urllib.parse import urlparse, urlunparse
+
+import aiohttp
+
+from .const import HASS_API_URL
+from .vocabulary import RecognitionContext, clean_names
+
+_LOGGER = logging.getLogger(__name__)
+
+Command = Callable[[Dict[str, Any]], Coroutine[Any, Any, Dict[str, Any]]]
+
+
+class HomeAssistantError(Exception):
+    """Home Assistant refused a request or the connection failed."""
+
+
+class HomeAssistant:
+    """Read-only client for the names speech-to-text biases toward."""
+
+    def __init__(
+        self,
+        token: str,
+        api_url: str = HASS_API_URL,
+        timeout: float = 10.0,
+    ) -> None:
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.timeout = timeout
+
+        parsed = urlparse(self.api_url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+
+        scheme = "wss" if parsed.scheme == "https" else "ws"
+        self.websocket_api_url = urlunparse(
+            parsed._replace(
+                scheme=scheme,
+                path=f"{parsed.path}/websocket",
+                params="",
+                query="",
+                fragment="",
+            )
+        )
+
+    async def get_context(self) -> RecognitionContext:
+        """Fetch the current names. Raises HomeAssistantError on failure."""
+        current_id = 0
+
+        def next_id() -> int:
+            nonlocal current_id
+            current_id += 1
+            return current_id
+
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.ws_connect(
+                    self.websocket_api_url, max_msg_size=0
+                ) as websocket:
+
+                    async def command(payload: Dict[str, Any]) -> Dict[str, Any]:
+                        """One request, one reply. We subscribe to nothing, so
+                        nothing else can arrive in between."""
+                        await websocket.send_json({"id": next_id(), **payload})
+                        msg = await websocket.receive_json()
+                        if not msg.get("success"):
+                            raise HomeAssistantError(f"{payload['type']} failed: {msg}")
+
+                        return msg
+
+                    await self._authenticate(websocket)
+                    return await self._load(command)
+        except HomeAssistantError:
+            raise
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to load names: {exc}") from exc
+
+    async def _authenticate(self, websocket: Any) -> None:
+        msg = await websocket.receive_json()
+        if msg.get("type") != "auth_required":
+            raise HomeAssistantError(f"Expected auth_required, got {msg}")
+
+        await websocket.send_json({"type": "auth", "access_token": self.token})
+        msg = await websocket.receive_json()
+        if msg.get("type") != "auth_ok":
+            raise HomeAssistantError(f"Authentication failed: {msg}")
+
+    async def _load(self, command: Command) -> RecognitionContext:
+        # Entities the user exposed to conversation. Nothing else is a possible
+        # target of a voice command.
+        msg = await command({"type": "homeassistant/expose_entity/list"})
+        exposed: Set[str] = {
+            entity_id
+            for entity_id, info in (msg["result"]["exposed_entities"] or {}).items()
+            if info.get("conversation")
+        }
+
+        # The displayed (friendly) name is what Home Assistant itself matches and
+        # what a user reading their dashboard will say. The registry's
+        # name/original_name may have had the device prefix stripped, leaving
+        # "Blinds" where the entity shows as "Bedroom Blinds"; biasing toward
+        # that fragment would put a bare cover-class word into the prompt.
+        friendly: Dict[str, str] = {}
+        msg = await command({"type": "get_states"})
+        for state in msg["result"]:
+            entity_id = state["entity_id"]
+            if entity_id not in exposed:
+                continue
+
+            attributes = state.get("attributes") or {}
+            name = " ".join((attributes.get("friendly_name") or "").split())
+            if name:
+                friendly[entity_id] = name
+
+        # Aliases only come with the extended registry entries, so exposed
+        # entities are fetched a second time to get them. An alias is what a
+        # speaker actually says when the integration's own name is not it.
+        entries: Dict[str, Dict[str, Any]] = {}
+        if exposed:
+            msg = await command(
+                {
+                    "type": "config/entity_registry/get_entries",
+                    "entity_ids": sorted(exposed),
+                }
+            )
+            entries = {k: v for k, v in msg["result"].items() if v}
+
+        entity_names: List[str] = []
+        alias_names: List[str] = []
+        unnamed: List[str] = []
+        for entity_id in sorted(exposed):
+            entry = entries.get(entity_id) or {}
+            if entry.get("disabled_by") is not None:
+                continue
+
+            name = friendly.get(entity_id) or entry.get("name") or ""
+            if not name:
+                name = entry.get("original_name") or ""
+
+            if name:
+                entity_names.append(name)
+            else:
+                unnamed.append(entity_id)
+
+            alias_names.extend(entry.get("aliases") or [])
+
+        area_names: List[str] = []
+        msg = await command({"type": "config/area_registry/list"})
+        for area in msg["result"]:
+            area_names.append(area.get("name") or "")
+            area_names.extend(area.get("aliases") or [])
+
+        floor_names: List[str] = []
+        msg = await command({"type": "config/floor_registry/list"})
+        for floor in msg["result"]:
+            floor_names.append(floor.get("name") or "")
+            floor_names.extend(floor.get("aliases") or [])
+
+        context = RecognitionContext(
+            areas=clean_names(area_names),
+            floors=clean_names(floor_names),
+            entities=clean_names(entity_names),
+            aliases=clean_names(alias_names),
+        )
+        # One line per fetch: this runs once per utterance, so anything per-entity
+        # here would bury the rest of the log.
+        _LOGGER.debug(
+            "Loaded names from Home Assistant: %s areas, %s floors, "
+            "%s entities, %s aliases%s",
+            len(context.areas),
+            len(context.floors),
+            len(context.entities),
+            len(context.aliases),
+            (
+                f" (skipped {len(unnamed)} unnamed: {', '.join(unnamed)})"
+                if unnamed
+                else ""
+            ),
+        )
+        return context
+
+
+__all__ = [
+    "HASS_API_URL",
+    "HomeAssistant",
+    "HomeAssistantError",
+]

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -336,7 +336,10 @@ def guess_model(
         return "gigaam-v2-rnnt"
 
     if stt_library == SttLibrary.QWEN3_ASR:
-        return "rhasspy/qwen3-asr-0.6b-onnx-int4"
+        # Merged decoder: same weights as qwen3-asr-0.6b-onnx-int4, but the
+        # biasing prompt's KV cache is reusable and the package is 785 MB rather
+        # than 1.4 GB. The split repo still works if given explicitly.
+        return "rhasspy/qwen3-asr-0.6b-onnx-int4-merged"
 
     if stt_library == SttLibrary.FUNASR:
         return "FunAudioLLM/SenseVoiceSmall"

--- a/wyoming_faster_whisper/name_cache.py
+++ b/wyoming_faster_whisper/name_cache.py
@@ -1,0 +1,194 @@
+"""Keep Home Assistant's names fresh without making the user wait for them.
+
+The refresh is timed to hide inside the utterance. When ``AudioStart`` arrives
+the speaker has not finished talking -- a voice command runs a couple of seconds
+-- so a fetch kicked off there has ample time to land before ``AudioStop``, when
+the prompt is actually needed. By then the names are current, and nothing was
+added to the latency the user perceives.
+
+Everything degrades to the last good snapshot. A fetch that fails, or is still
+in flight when the audio stops, costs freshness and nothing else: the previous
+names are used, or the configured ``--initial-prompt`` alone if there has never
+been a successful fetch. Home Assistant being unreachable must never turn into a
+failed transcription.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+from .const import Transcriber
+from .hass_api import HomeAssistant, HomeAssistantError
+from .vocabulary import (
+    DEFAULT_PROMPT_MAX_TOKENS,
+    CountTokens,
+    RecognitionContext,
+    estimate_tokens,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HassNameCache:
+    """A snapshot of Home Assistant's names, refreshed in the background."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        prefix: Optional[str] = None,
+        max_tokens: int = DEFAULT_PROMPT_MAX_TOKENS,
+        refresh_seconds: float = 0.0,
+        wait_timeout: float = 1.0,
+    ) -> None:
+        self._hass = hass
+        self._prefix = prefix
+        self._max_tokens = max_tokens
+
+        # 0 refreshes on every utterance; a positive value throttles.
+        self._refresh_seconds = refresh_seconds
+
+        # How long AudioStop will wait on a fetch that has not landed yet.
+        self._wait_timeout = wait_timeout
+
+        self._context: Optional[RecognitionContext] = None
+        self._updated: Optional[float] = None
+        self._task: Optional[asyncio.Task] = None
+
+        # Whether the previous attempt succeeded, so a broken Home Assistant is
+        # reported once instead of on every utterance.
+        self._was_ok = True
+
+    @property
+    def has_names(self) -> bool:
+        """Whether a fetch has ever succeeded."""
+        return self._context is not None
+
+    def schedule_refresh(self) -> None:
+        """Start a refresh in the background, if one is due and none is running.
+
+        Safe to call on every AudioStart from every connection: concurrent calls
+        collapse onto the one in-flight fetch.
+        """
+        if (self._task is not None) and (not self._task.done()):
+            # Already in flight.
+            return
+
+        if not self._is_stale():
+            return
+
+        self._task = asyncio.create_task(self._refresh())
+
+    async def refresh(self) -> bool:
+        """Refresh now and report whether names are available afterward.
+
+        Used at start-up so the very first utterance is biased too.
+        """
+        await self._refresh()
+        return self.has_names
+
+    async def wait_for_refresh(self) -> None:
+        """Give an in-flight refresh a bounded chance to land."""
+        task = self._task
+        if (task is None) or task.done():
+            return
+
+        try:
+            # Shielded: a timeout here must not cancel the fetch. It keeps
+            # running and its names are used by the next utterance.
+            await asyncio.wait_for(asyncio.shield(task), timeout=self._wait_timeout)
+        except asyncio.TimeoutError:
+            _LOGGER.debug(
+                "Names not refreshed within %ss; using the previous snapshot",
+                self._wait_timeout,
+            )
+
+    async def initial_prompt(
+        self,
+        transcriber: Optional[Transcriber] = None,
+        wait: bool = True,
+    ) -> Optional[str]:
+        """The prompt for this utterance: configured prefix plus current names.
+
+        ``wait`` is False on the streaming path, where the prompt is needed at
+        the start of the audio and there is nothing to wait for yet.
+        """
+        if wait:
+            await self.wait_for_refresh()
+
+        context = self._context
+        if context is None:
+            return self._prefix
+
+        prompt = context.whisper_prompt(
+            self._token_counter(transcriber),
+            max_tokens=self._max_tokens,
+            prefix=self._prefix,
+            tokenizer_key=_tokenizer_key(transcriber),
+        )
+        return prompt or self._prefix
+
+    def _is_stale(self) -> bool:
+        if self._updated is None:
+            return True
+
+        if self._refresh_seconds <= 0:
+            return True
+
+        return (time.monotonic() - self._updated) >= self._refresh_seconds
+
+    async def _refresh(self) -> None:
+        """Fetch the names, keeping the previous snapshot on failure."""
+        try:
+            context = await self._hass.get_context()
+        except HomeAssistantError as exc:
+            # Warn on the first failure of a run, then stay quiet: this runs once
+            # per utterance and an unreachable Home Assistant would flood the log.
+            if self._was_ok:
+                _LOGGER.warning("Failed to load names from Home Assistant: %s", exc)
+            else:
+                _LOGGER.debug(
+                    "Still failing to load names from Home Assistant: %s", exc
+                )
+
+            self._was_ok = False
+            return
+
+        self._was_ok = True
+        self._updated = time.monotonic()
+
+        if (self._context is not None) and (context == self._context):
+            # Nothing was renamed. Keep the existing instance so the prompt it
+            # already built stays cached and no tokenizing is repeated -- which
+            # is what makes refreshing on every utterance cheap.
+            return
+
+        self._context = context
+        _LOGGER.debug("Names updated (%s total)", len(context.all_names()))
+
+    def _token_counter(self, transcriber: Optional[Transcriber]) -> CountTokens:
+        """Count with the model's own tokenizer, or estimate if it has none."""
+
+        def count(text: str) -> int:
+            if transcriber is not None:
+                tokens = transcriber.count_prompt_tokens(text)
+                if tokens is not None:
+                    return tokens
+
+            return estimate_tokens(text)
+
+        return count
+
+
+def _tokenizer_key(transcriber: Optional[Transcriber]) -> str:
+    """Identify a transcriber's tokenizer for prompt caching.
+
+    ``id()`` is stable here because ModelLoader caches transcribers for the life
+    of the process, so one is never freed and its address never reused.
+    """
+    if transcriber is None:
+        return "estimate"
+
+    return f"{type(transcriber).__name__}:{id(transcriber)}"

--- a/wyoming_faster_whisper/qwen3_asr_handler.py
+++ b/wyoming_faster_whisper/qwen3_asr_handler.py
@@ -2,14 +2,28 @@
 
 Qwen3-ASR is a speech LLM: an audio encoder feeds projected audio embeddings into
 a Qwen3 decoder that generates the transcript token by token. The ONNX export
-splits it into three graphs (encoder, decoder prefill, decoder step), so unlike
-the other backends there is no library that drives it for us - the greedy decode
-loop lives here.
+splits it into several graphs, so unlike the other backends there is no library
+that drives it for us - the greedy decode loop lives here.
 
 The payoff is context biasing. Qwen3-ASR accepts free-form text in the chat
 template's system turn to bias decoding toward specific spellings, so
 ``--initial-prompt`` can carry Home Assistant entity names ("Vocabulary: Ecobee,
 office lamp.") and fix names that would otherwise be transcribed phonetically.
+
+Two decoder layouts are supported, chosen by which files the model directory has:
+
+*merged* (``decoder_merged.int4.onnx``) - one graph taking a KV cache *and* a
+dynamic sequence length. Because the biasing prompt sits in the system turn,
+ahead of the audio, its KV depends only on the prompt tokens, so it is computed
+once and reused for every later utterance. That matters because the prompt is not
+free: a 50-name list is ~180 tokens of prefill, which on a Pi 5 took a 3.2 s
+command from 1.47 s to 3.42 s. Reusing it gives 2.20 s, and the graph also drops
+the in-graph embedding table (1407 -> 785 MB on disk, 2.25 -> 1.55 GB peak RSS).
+
+*split* (``decoder_init`` + ``decoder_step``) - the original export. ``decoder_init``
+has no KV input and ``decoder_step`` is pinned to one token, so the prompt must be
+re-prefilled every utterance. Kept as a fallback so existing model directories
+keep working.
 
 onnxruntime is imported at module scope (not lazily inside __init__) so that
 importing this module raises ImportError when it is absent. ModelLoader relies on
@@ -19,6 +33,7 @@ onnx_asr_handler/funasr_handler.
 
 import json
 import logging
+import threading
 import wave
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
@@ -66,10 +81,21 @@ _ALLOW_PATTERNS = [
     "embed_tokens.bin",
     "encoder.int4.onnx",
     "encoder.int4.onnx.data",
+    # Merged layout.
+    "decoder_merged.int4.onnx",
+    "decoder_merged.int4.onnx.data",
+    # Split layout. A repo has one layout or the other, and patterns that match
+    # nothing are simply skipped, so one list serves both.
     "decoder_init.int4.onnx",
     "decoder_step.int4.onnx",
     "decoder_weights.int4.data",
 ]
+
+# Presence of this file selects the merged layout.
+_MERGED_DECODER = "decoder_merged.int4.onnx"
+
+# Additive attention mask: 0 where attending is allowed, this where it is not.
+_MASK_BLOCKED = np.finfo(np.float32).min
 
 # Language names the model was trained to accept in the forced-language suffix.
 _LANGUAGE_NAMES = {
@@ -176,6 +202,31 @@ def _log_mel_spectrogram(audio: np.ndarray, mel_filters: np.ndarray) -> np.ndarr
     return log_spec[np.newaxis, :, :].astype(np.float32)
 
 
+def _system_ids(context_ids: Sequence[int]) -> List[int]:
+    """The chat template's system turn, which is where the biasing context goes.
+
+    Split out because it is exactly the span whose KV the merged decoder caches:
+    it precedes the audio, so nothing in it changes from one utterance to the next.
+    """
+    return [_IM_START, _SYSTEM, _NEWLINE, *context_ids, _IM_END, _NEWLINE]
+
+
+def _causal_mask(q_len: int, past_len: int) -> np.ndarray:
+    """[1, 1, q_len, past_len + q_len] additive mask for the merged decoder.
+
+    New tokens may attend to everything already in the cache, and causally among
+    themselves. Built here rather than inside the graph because deriving it from
+    input shapes is the kind of shape arithmetic the ONNX exporter freezes into
+    constants.
+    """
+    new = np.triu(np.full((q_len, q_len), _MASK_BLOCKED, dtype=np.float32), k=1)
+    if past_len == 0:
+        return new[np.newaxis, np.newaxis]
+
+    past = np.zeros((q_len, past_len), dtype=np.float32)
+    return np.concatenate([past, new], axis=-1)[np.newaxis, np.newaxis]
+
+
 class Qwen3AsrTranscriber(Transcriber):
     """Wrapper for a Qwen3-ASR ONNX export (encoder + split decoder)."""
 
@@ -209,12 +260,43 @@ class Qwen3AsrTranscriber(Transcriber):
         self._encoder = ort.InferenceSession(
             str(model_dir / "encoder.int4.onnx"), **session_args
         )
-        self._decoder_init = ort.InferenceSession(
-            str(model_dir / "decoder_init.int4.onnx"), **session_args
-        )
-        self._decoder_step = ort.InferenceSession(
-            str(model_dir / "decoder_step.int4.onnx"), **session_args
-        )
+
+        self._merged: Optional[ort.InferenceSession] = None
+        self._decoder_init: Optional[ort.InferenceSession] = None
+        self._decoder_step: Optional[ort.InferenceSession] = None
+
+        if (model_dir / _MERGED_DECODER).is_file():
+            self._merged = ort.InferenceSession(
+                str(model_dir / _MERGED_DECODER), **session_args
+            )
+            # present_keys is [num_layers, batch, kv_heads, seq, head_dim]; the
+            # non-sequence dims are static, so the empty cache that starts a
+            # prefill can be shaped from the graph instead of from config.json.
+            kv_shape = self._merged.get_outputs()[1].shape
+            self._empty_kv = np.zeros(
+                (kv_shape[0], 1, kv_shape[2], 0, kv_shape[4]), dtype=np.float32
+            )
+            _LOGGER.debug("Using merged decoder (biasing prompt KV is reused)")
+        else:
+            self._decoder_init = ort.InferenceSession(
+                str(model_dir / "decoder_init.int4.onnx"), **session_args
+            )
+            self._decoder_step = ort.InferenceSession(
+                str(model_dir / "decoder_step.int4.onnx"), **session_args
+            )
+            _LOGGER.debug(
+                "Using split decoder; the biasing prompt is re-prefilled every "
+                "utterance. A model directory with %s avoids that.",
+                _MERGED_DECODER,
+            )
+
+        # Cached KV for the system turn, merged layout only. Exactly one entry:
+        # Home Assistant sends the same name list every time, and each entry is
+        # substantial (~42 MB for a 180-token prompt), so keeping a history would
+        # cost far more memory than it could ever save.
+        self._prefix_lock = threading.Lock()
+        self._prefix_key: Optional[Tuple[int, ...]] = None
+        self._prefix_kv: Optional[Tuple[np.ndarray, np.ndarray]] = None
 
         with open(model_dir / "config.json", "r", encoding="utf-8") as config_file:
             config = json.load(config_file)
@@ -230,6 +312,9 @@ class Qwen3AsrTranscriber(Transcriber):
         self._mel_filters = _mel_filterbank()
         self._encoder_inputs = [inp.name for inp in self._encoder.get_inputs()]
         self._prompt_cache: Dict[Tuple[str, Optional[str]], List[int]] = {}
+
+    def count_prompt_tokens(self, text: str) -> Optional[int]:
+        return len(self._tokenizer.encode(text, add_special_tokens=False).ids)
 
     def _context_ids(
         self, initial_prompt: Optional[str], language: Optional[str]
@@ -272,15 +357,105 @@ class Qwen3AsrTranscriber(Transcriber):
         <|im_start|>assistant\n{language {Name}<asr_text>}
         """
         return (
-            [_IM_START, _SYSTEM, _NEWLINE, *context_ids, _IM_END, _NEWLINE]
+            _system_ids(context_ids)
             + [_IM_START, _USER, _NEWLINE, _AUDIO_START]
             + [_AUDIO_PAD] * n_audio_tokens
             + [_AUDIO_END, _IM_END, _NEWLINE]
             + [_IM_START, _ASSISTANT, _NEWLINE, *language_ids]
         )
 
+    def _run_merged(
+        self,
+        input_embeds: np.ndarray,
+        positions: Union[Sequence[int], np.ndarray],
+        past_keys: np.ndarray,
+        past_values: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """One pass of the merged decoder over ``input_embeds``."""
+        assert self._merged is not None
+        return self._merged.run(
+            ["logits", "present_keys", "present_values"],
+            {
+                "input_embeds": input_embeds,
+                "position_ids": np.asarray(positions, dtype=np.int64)[np.newaxis, :],
+                "attention_mask": _causal_mask(
+                    input_embeds.shape[1], past_keys.shape[3]
+                ),
+                "past_keys": past_keys,
+                "past_values": past_values,
+            },
+        )
+
+    def _prefix_cache(self, system_ids: List[int]) -> Tuple[np.ndarray, np.ndarray]:
+        """KV for the system turn, computed once and reused while it is unchanged."""
+        key = tuple(system_ids)
+        with self._prefix_lock:
+            if (self._prefix_key == key) and (self._prefix_kv is not None):
+                return self._prefix_kv
+
+        # Run outside the lock: this is a model pass, and holding the lock would
+        # serialize concurrent requests behind it. Two callers racing here just
+        # compute the same thing twice and store the same result.
+        _, keys, values = self._run_merged(
+            self._embed_tokens[system_ids].astype(np.float32)[np.newaxis, :, :],
+            np.arange(len(system_ids)),
+            self._empty_kv,
+            self._empty_kv,
+        )
+
+        with self._prefix_lock:
+            self._prefix_key = key
+            self._prefix_kv = (keys, values)
+
+        _LOGGER.debug("Cached KV for a %s-token system turn", len(system_ids))
+        return keys, values
+
+    def _generate_merged(
+        self,
+        audio_features: np.ndarray,
+        prompt_ids: List[int],
+        n_system: int,
+    ) -> List[int]:
+        """Greedy decode reusing the system turn's KV across utterances."""
+        past_keys, past_values = self._prefix_cache(prompt_ids[:n_system])
+
+        # Everything after the system turn: the audio placeholders and the
+        # assistant preamble. Audio features replace the placeholder embeddings.
+        rest = prompt_ids[n_system:]
+        input_embeds = self._embed_tokens[rest].astype(np.float32)[np.newaxis, :, :]
+        audio_at = prompt_ids.index(_AUDIO_PAD) - n_system
+        input_embeds[0, audio_at : audio_at + audio_features.shape[1]] = audio_features[
+            0
+        ]
+
+        logits, past_keys, past_values = self._run_merged(
+            input_embeds,
+            np.arange(n_system, len(prompt_ids)),
+            past_keys,
+            past_values,
+        )
+
+        token = int(np.argmax(logits[0, -1, :]))
+        tokens = [token]
+        position = len(prompt_ids)
+
+        while (token not in _EOS_IDS) and (len(tokens) < _MAX_NEW_TOKENS):
+            logits, past_keys, past_values = self._run_merged(
+                self._embed_tokens[token].astype(np.float32)[np.newaxis, np.newaxis, :],
+                [position],
+                past_keys,
+                past_values,
+            )
+            token = int(np.argmax(logits[0, -1, :]))
+            tokens.append(token)
+            position += 1
+
+        return tokens
+
     def _generate(self, audio_features: np.ndarray, prompt_ids: List[int]) -> List[int]:
-        """Greedy decode: prefill the prompt, then step one token at a time."""
+        """Greedy decode on the split layout: prefill, then one token at a time."""
+        assert (self._decoder_init is not None) and (self._decoder_step is not None)
+
         logits, past_keys, past_values = self._decoder_init.run(
             ["logits", "present_keys", "present_values"],
             {
@@ -351,7 +526,13 @@ class Qwen3AsrTranscriber(Transcriber):
         prompt_ids = self._build_prompt_ids(
             audio_features.shape[1], context_ids, language_ids
         )
-        tokens = self._generate(audio_features, prompt_ids)
+
+        if self._merged is not None:
+            tokens = self._generate_merged(
+                audio_features, prompt_ids, len(_system_ids(context_ids))
+            )
+        else:
+            tokens = self._generate(audio_features, prompt_ids)
 
         # The model writes the detected language before <asr_text>; drop it.
         if _ASR_TEXT in tokens:

--- a/wyoming_faster_whisper/vocabulary.py
+++ b/wyoming_faster_whisper/vocabulary.py
@@ -1,0 +1,177 @@
+"""Turn Home Assistant names into a budgeted biasing prompt.
+
+Whisper accepts an ``initial_prompt`` that conditions the decoder, and biasing it
+toward the names in the user's home is the cheapest accuracy win available: it
+takes proper nouns the model has never heard ("Ecobee", "Nanit") from garbage to
+correct without changing model, audio, or decode settings. Qwen3-ASR takes the
+same string as its context prompt.
+
+The catch is size. Whisper's decoder context is 448 tokens and the prompt is
+hard-capped at ``max_length // 2 - 1`` == 223, past which it is silently
+truncated -- and quality degrades well before the cap, because a long prompt
+makes the model hallucinate and echo words that were never spoken. A house with
+200 exposed entities cannot be sent wholesale, so the names are placed in
+priority order and cut off at a budget:
+
+  1. areas, then floors -- few in number and spoken in nearly every command
+     ("turn on the *office* lamp"), so they are cheap and near-certain to pay off
+  2. entity names -- the actual proper nouns, the high-value biasing targets
+  3. entity aliases -- alternate phrasings, valuable but redundant with (2)
+
+Truncation is deliberate and deterministic: fill in that order, stop at the
+first name that would not fit, and log what was dropped. No scoring, no
+sampling -- the same home produces the same prompt every time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+_LOGGER = logging.getLogger(__name__)
+
+# Stay well under Whisper's hard cap of 223.
+DEFAULT_PROMPT_MAX_TOKENS = 200
+
+# Counts tokens in a candidate prompt using the model's own tokenizer.
+CountTokens = Callable[[str], int]
+
+# Punctuation that already separates a prefix from the name list.
+_PREFIX_ENDINGS = (".", ":", ",", ";", "!", "?")
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate a token count when the model's tokenizer is unavailable.
+
+    Deliberately an over-estimate. Going under means Whisper silently truncates
+    the prompt, which is worse than fitting fewer names than we could have.
+
+    Measured against Whisper's own BPE, a comma-joined list of realistic entity
+    names runs about 2.95 characters per token, so 2 leaves comfortable headroom.
+    This is only ever called on a whole candidate prompt, which is long; a very
+    short string on its own can still come in under (rare names are dense --
+    "Nanit" is 5 characters but 3 tokens), and that does not matter here.
+    """
+    return max(1, len(text) // 2)
+
+
+def clean_names(*groups: Iterable[Any]) -> List[str]:
+    """Merge name groups in order: strip, collapse whitespace, de-dupe.
+
+    De-duplication is case-insensitive and keeps the first spelling seen, so a
+    name that appears as both an area and an alias is only paid for once.
+    """
+    names: List[str] = []
+    seen = set()
+    for group in groups:
+        for value in group or ():
+            if not isinstance(value, str):
+                continue
+
+            name = " ".join(value.split()).strip()
+            key = name.lower()
+            if name and (key not in seen):
+                seen.add(key)
+                names.append(name)
+
+    return names
+
+
+@dataclass
+class RecognitionContext:
+    """The names from one snapshot of Home Assistant, in priority order.
+
+    A new snapshot is a new instance, so the prompt cache below dies with the
+    names it was built from.
+    """
+
+    areas: List[str] = field(default_factory=list)
+    floors: List[str] = field(default_factory=list)
+    entities: List[str] = field(default_factory=list)
+    aliases: List[str] = field(default_factory=list)
+
+    # Cached by (prefix, budget, tokenizer). Building the prompt costs one
+    # tokenizer call per name, and the same prompt is reused for every utterance
+    # until the names change.
+    _prompts: Dict[Tuple[str, int, str], Optional[str]] = field(
+        default_factory=dict, compare=False, repr=False
+    )
+
+    def all_names(self) -> List[str]:
+        """Every name in priority order, de-duped across the buckets."""
+        return clean_names(self.areas, self.floors, self.entities, self.aliases)
+
+    def __bool__(self) -> bool:
+        return bool(self.areas or self.floors or self.entities or self.aliases)
+
+    def whisper_prompt(
+        self,
+        count_tokens: CountTokens,
+        max_tokens: int = DEFAULT_PROMPT_MAX_TOKENS,
+        prefix: Optional[str] = None,
+        tokenizer_key: str = "",
+    ) -> Optional[str]:
+        """A comma-joined prompt of as many names as fit within ``max_tokens``.
+
+        ``count_tokens`` should use the model's own tokenizer so the budget is
+        exact for that model; ``tokenizer_key`` identifies it for caching.
+        ``prefix`` is the server's configured ``--initial-prompt``, kept at the
+        front and always included -- an explicit setting outranks anything
+        discovered from Home Assistant.
+
+        Returns None when there is nothing to send at all.
+        """
+        key = (prefix or "", max_tokens, tokenizer_key)
+        if key not in self._prompts:
+            self._prompts[key] = self._build_prompt(count_tokens, max_tokens, prefix)
+
+        return self._prompts[key]
+
+    def _build_prompt(
+        self,
+        count_tokens: CountTokens,
+        max_tokens: int,
+        prefix: Optional[str],
+    ) -> Optional[str]:
+        """Fill the budget in priority order, stopping at the first name that
+        does not fit."""
+        head = (prefix or "").strip()
+        if head and not head.endswith(_PREFIX_ENDINGS):
+            # So the prefix reads as its own sentence rather than running into
+            # the first name.
+            head += "."
+
+        names = self.all_names()
+        if not names:
+            return head or None
+
+        chosen: List[str] = []
+        for name in names:
+            candidate = _join(head, chosen + [name])
+            if count_tokens(candidate) > max_tokens:
+                break
+
+            chosen.append(name)
+
+        if len(chosen) < len(names):
+            _LOGGER.debug(
+                "Prompt budget of %s tokens fit %s/%s names; %s dropped",
+                max_tokens,
+                len(chosen),
+                len(names),
+                len(names) - len(chosen),
+            )
+
+        if not chosen:
+            # Not even one name fits, which means the budget is smaller than the
+            # prefix. Send the prefix alone rather than nothing.
+            return head or None
+
+        return _join(head, chosen)
+
+
+def _join(head: str, names: List[str]) -> str:
+    """Render a prefix and a name list as the final prompt string."""
+    body = ", ".join(names) + "."
+    return f"{head} {body}" if head else body


### PR DESCRIPTION
Two related changes: biasing speech-to-text toward the names in the user's home, and removing most of what that biasing costs on `qwen3-asr`.

## Bias toward Home Assistant names

Whisper has no reason to think "Ecobee" is a word, so it comes back as "incubi" even when the acoustics are fine. Given `--hass-token`, the server reads the names in the user's home over the HA websocket API and feeds them to the model as a prompt.

- Conversation-exposed entities and their aliases, plus area and floor names — the names a speaker can actually say. Read-only; no service is ever called.
- **The fetch starts at `AudioStart`, not `AudioStop`**, so it runs while the speaker is still talking and costs no latency. `AudioStop` waits at most `--hass-prompt-timeout`, shielded so a timeout doesn't cancel the fetch — it lands for the next utterance instead.
- A slow or unreachable Home Assistant falls back to the previous names, or to `--initial-prompt` alone, and never fails a transcript.
- Names fill a token budget in priority order (areas, floors, entity names, aliases), because Whisper's prompt is hard-capped at 223 tokens and quality degrades before that.

No transcriber signatures change: every backend already accepts `initial_prompt`, so the dispatch handler substitutes the HA-derived prompt for the configured one. The only addition to the `Transcriber` ABC is `count_prompt_tokens()`, so the budget can be measured with the model's own tokenizer.

## Make the prompt cheap on qwen3-asr

The prompt isn't free on `qwen3-asr` — the model reads it before decoding starts, at ~2.8ms/token, so a 50-name list roughly doubled the time for a short command. That prompt sits ahead of the audio, so its attention state depends only on the prompt tokens and can be computed once.

The existing export can't exploit that (`decoder_init` takes no KV cache; `decoder_step` is pinned to one token), so this adds support for a merged decoder graph that takes both. Selected automatically from the files present; directories with `decoder_init`/`decoder_step` keep working.

Pi 5, 4 threads, 3.2s command, 50 names:

| | split | merged |
| --- | --- | --- |
| latency | 3.42s | 2.20s |
| peak RSS | 2.25 GB | 1.55 GB |
| on disk | 1407 MB | 785 MB |

The default model moves to [`rhasspy/qwen3-asr-0.6b-onnx-int4-merged`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4-merged). The split repo stays published and still works when passed explicitly.

## Accuracy

LibriSpeech test-other, n=200, both layouts driven through the shipped `Qwen3AsrTranscriber` on identical samples:

| condition | split | merged | differing |
| --- | --- | --- | --- |
| bare | 5.35% | 5.35% | **0/200** |
| 50 names | 5.43% | 5.33% | 14/200 |

With no prompt the two produce byte-identical transcripts on every sample. With a prompt the merged path splits prefill into prefix + remainder, which changes accumulation order enough to flip 14 near-ties; the delta is well inside sampling noise at n=200. A 50-name prompt irrelevant to audiobook speech doesn't degrade general transcription either way (+0.07% split, −0.02% merged) — worth knowing, since HA users run with a prompt permanently on.

## Not covered

- **Multilingual is untested** on either decoder layout. Equally true of the currently published model, so not a regression, but it is untested ground.
- The latency win is for short commands; long-form audio gains ~1.04x, though the memory saving grows with length (4.16 GB → 2.87 GB on a 30s clip).

## Tests

147 passed / 2 xfailed, lint 10.00/10. New coverage: prompt budgeting, the HA websocket client (against a real local websocket server), background refresh and its degradation paths, the dispatch wiring end-to-end, and the merged decoder's cached span and attention mask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)