### PR TITLE
Let --vad-clip name the libraries it applies to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4-merged`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4-merged)
 - `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
 - Qwen3-ASR is opt-in only (`auto` never selects it): the model is 785 MB and needs ~1.6 GB of RAM, and it is slower than the per-language defaults
+- `--vad-clip` now takes optional speech-to-text libraries, so clipping can be enabled only where it pays off: `--vad-clip qwen3-asr` clips for that backend alone, while a bare `--vad-clip` still applies to every library. Qwen3-ASR costs ~235 ms per second of audio on a Pi 5 (encoder, prefill, *and* per-token decode all scale with input length), so trimming silence off a typical command saves ~20%; faster-whisper pads to 30s internally and gains nothing
 
 ## 3.5.0
 

--- a/tests/test_dispatch_handler.py
+++ b/tests/test_dispatch_handler.py
@@ -9,7 +9,7 @@ refresh, AudioStop waits for it, and the resulting prompt reaches
 import asyncio
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import pytest
 
@@ -20,9 +20,14 @@ from wyoming.asr import Transcribe, Transcript  # noqa: E402
 from wyoming.audio import AudioChunk, AudioStart, AudioStop  # noqa: E402
 from wyoming.info import Info  # noqa: E402
 
-from wyoming_faster_whisper.const import StreamingSession, Transcriber  # noqa: E402
+from wyoming_faster_whisper.const import (  # noqa: E402
+    SttLibrary,
+    StreamingSession,
+    Transcriber,
+)
 from wyoming_faster_whisper.dispatch_handler import DispatchEventHandler  # noqa: E402
 from wyoming_faster_whisper.hass_api import HomeAssistantError  # noqa: E402
+from wyoming_faster_whisper.models import vad_clip_enabled  # noqa: E402
 from wyoming_faster_whisper.name_cache import HassNameCache  # noqa: E402
 from wyoming_faster_whisper.vocabulary import RecognitionContext  # noqa: E402
 
@@ -68,6 +73,7 @@ class FakeTranscriber(Transcriber):
                 "language": language,
                 "beam_size": beam_size,
                 "initial_prompt": initial_prompt,
+                "wav_path": str(wav_path),
             }
         )
         return "fake transcript"
@@ -113,9 +119,17 @@ class FakeLoader:
         self.vad_clip = False
         self.vad_clip_threshold = 0.5
         self.vad_clip_pad_ms = 400
+        self.vad_clip_libraries: Optional[Set[SttLibrary]] = None
+        self.stt_library = SttLibrary.QWEN3_ASR
 
     async def load_transcriber(self, language: Optional[str] = None) -> Transcriber:
         return self.transcriber
+
+    def should_vad_clip(self, language: Optional[str] = None) -> bool:
+        # Defer to the real predicate so the fake cannot drift from production.
+        return vad_clip_enabled(
+            self.stt_library, self.vad_clip, self.vad_clip_libraries
+        )
 
 
 class FakeHass:
@@ -406,3 +420,42 @@ async def test_a_streaming_session_does_not_wait_for_a_slow_fetch():
 
     assert transcriber.sessions[0].initial_prompt == "Vocabulary:"
     assert elapsed < 1.0, f"streaming start blocked for {elapsed:.1f}s"
+
+
+# --- --vad-clip library selection -----------------------------------------
+
+
+async def test_clipping_is_skipped_for_a_library_that_was_not_named():
+    """`--vad-clip qwen3-asr` must not clip for other backends."""
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber)
+    handler._loader.vad_clip = True
+    handler._loader.vad_clip_libraries = {SttLibrary.QWEN3_ASR}
+    handler._loader.stt_library = SttLibrary.FASTER_WHISPER
+
+    await _utterance(handler)
+
+    # The untouched recording is transcribed, not the clipped copy.
+    assert transcriber.calls[-1]["wav_path"] == handler._wav_path
+
+
+async def test_clipping_is_attempted_for_a_named_library():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber)
+    handler._loader.vad_clip = True
+    handler._loader.vad_clip_libraries = {SttLibrary.QWEN3_ASR}
+    handler._loader.stt_library = SttLibrary.QWEN3_ASR
+
+    clipped: List[str] = []
+
+    def fake_clip(src, dst, threshold, pad_ms) -> bool:
+        clipped.append(str(src))
+        return False  # silence only: fall back to the original WAV
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            "wyoming_faster_whisper.dispatch_handler.clip_wav_to_speech", fake_clip
+        )
+        await _utterance(handler)
+
+    assert clipped == [handler._wav_path]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ as arguments, so the real STT backends need not be installed.
 import pytest
 
 from wyoming_faster_whisper.const import SttLibrary
-from wyoming_faster_whisper.models import guess_stt_library
+from wyoming_faster_whisper.models import guess_stt_library, vad_clip_enabled
 
 _ALL_AVAILABLE = dict(
     has_transformers=True,
@@ -52,8 +52,7 @@ def test_auto_selects_per_language_backend(language, expected) -> None:
 def test_auto_funasr_languages_fall_back_when_funasr_missing() -> None:
     # zh would route to FunASR, but it isn't installed -> faster-whisper.
     assert (
-        _guess(SttLibrary.AUTO, "zh-CN", has_funasr=False)
-        == SttLibrary.FASTER_WHISPER
+        _guess(SttLibrary.AUTO, "zh-CN", has_funasr=False) == SttLibrary.FASTER_WHISPER
     )
 
 
@@ -74,8 +73,7 @@ def test_explicit_funasr_kept_when_available() -> None:
 
 def test_explicit_funasr_falls_back_when_missing() -> None:
     assert (
-        _guess(SttLibrary.FUNASR, "zh", has_funasr=False)
-        == SttLibrary.FASTER_WHISPER
+        _guess(SttLibrary.FUNASR, "zh", has_funasr=False) == SttLibrary.FASTER_WHISPER
     )
 
 
@@ -101,4 +99,52 @@ def test_explicit_faster_whisper_is_passthrough() -> None:
     assert (
         _guess(SttLibrary.FASTER_WHISPER, "en", has_sherpa=False)
         == SttLibrary.FASTER_WHISPER
+    )
+
+
+# --- --vad-clip library selection -----------------------------------------
+
+
+def test_vad_clip_off_when_flag_absent() -> None:
+    for library in SttLibrary:
+        assert not vad_clip_enabled(library, vad_clip=False)
+
+
+def test_bare_vad_clip_applies_to_every_library() -> None:
+    # `--vad-clip` with no values -> vad_clip_libraries is None.
+    for library in SttLibrary:
+        assert vad_clip_enabled(library, vad_clip=True, vad_clip_libraries=None)
+
+
+def test_named_library_is_clipped() -> None:
+    assert vad_clip_enabled(
+        SttLibrary.QWEN3_ASR, vad_clip=True, vad_clip_libraries={SttLibrary.QWEN3_ASR}
+    )
+
+
+def test_unnamed_libraries_are_not_clipped() -> None:
+    # `--vad-clip qwen3-asr` must leave faster-whisper alone, where clipping
+    # buys nothing (audio is padded to 30s internally regardless).
+    assert not vad_clip_enabled(
+        SttLibrary.FASTER_WHISPER,
+        vad_clip=True,
+        vad_clip_libraries={SttLibrary.QWEN3_ASR},
+    )
+
+
+def test_several_libraries_can_be_named() -> None:
+    named = {SttLibrary.QWEN3_ASR, SttLibrary.SHERPA}
+    assert vad_clip_enabled(SttLibrary.SHERPA, vad_clip=True, vad_clip_libraries=named)
+    assert vad_clip_enabled(
+        SttLibrary.QWEN3_ASR, vad_clip=True, vad_clip_libraries=named
+    )
+    assert not vad_clip_enabled(
+        SttLibrary.FUNASR, vad_clip=True, vad_clip_libraries=named
+    )
+
+
+def test_named_libraries_are_ignored_when_flag_is_off() -> None:
+    # Defensive: a stale library set must not enable clipping on its own.
+    assert not vad_clip_enabled(
+        SttLibrary.QWEN3_ASR, vad_clip=False, vad_clip_libraries={SttLibrary.QWEN3_ASR}
     )

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -118,8 +118,12 @@ async def main() -> None:
     )
     parser.add_argument(
         "--vad-clip",
-        action="store_true",
-        help="Use pysilero-vad to clip leading/trailing silence before transcription (default: disabled; use --vad-clip to enable)",
+        nargs="*",
+        metavar="STT_LIBRARY",
+        choices=[lib.value for lib in SttLibrary if lib != SttLibrary.AUTO],
+        help="Use pysilero-vad to clip leading/trailing silence before "
+        "transcription (default: disabled). Pass --vad-clip for every library, or "
+        "name the libraries it applies to, e.g. --vad-clip qwen3-asr",
     )
     parser.add_argument(
         "--vad-clip-threshold",
@@ -206,6 +210,13 @@ async def main() -> None:
 
     args.stt_library = SttLibrary(args.stt_library)
 
+    # argparse gives None when --vad-clip is absent, [] when it is passed with no
+    # values (every library), and the named libraries otherwise.
+    vad_clip = args.vad_clip is not None
+    vad_clip_libraries = (
+        {SttLibrary(value) for value in args.vad_clip} if args.vad_clip else None
+    )
+
     machine = platform.machine().lower()
     is_arm = ("arm" in machine) or ("aarch" in machine)
 
@@ -286,9 +297,10 @@ async def main() -> None:
         vad_parameters=vad_parameters,
         whisper_task=args.whisper_task,
         sherpa_streaming=args.sherpa_streaming,
-        vad_clip=args.vad_clip,
+        vad_clip=vad_clip,
         vad_clip_threshold=args.vad_clip_threshold,
         vad_clip_pad_ms=args.vad_clip_pad_ms,
+        vad_clip_libraries=vad_clip_libraries,
     )
 
     # Load model

--- a/wyoming_faster_whisper/dispatch_handler.py
+++ b/wyoming_faster_whisper/dispatch_handler.py
@@ -146,11 +146,13 @@ class DispatchEventHandler(AsyncEventHandler):
                 self._wav_file = None
 
                 # Optionally clip leading/trailing silence before transcription.
-                # This is backend-agnostic (operates on the WAV), so it applies
-                # to every batch transcriber, not just faster-whisper. Streaming
+                # This operates on the WAV, so any batch transcriber can use it;
+                # --vad-clip decides which libraries actually do. Streaming
                 # transcribers never reach this path.
                 wav_path = self._wav_path
-                if self._loader.vad_clip and await asyncio.to_thread(
+                if self._loader.should_vad_clip(
+                    self._language
+                ) and await asyncio.to_thread(
                     clip_wav_to_speech,
                     self._wav_path,
                     self._clipped_wav_path,

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -6,7 +6,7 @@ import logging
 import platform
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from .const import SttLibrary, Transcriber, sense_voice_language
 from .faster_whisper_handler import FasterWhisperTranscriber
@@ -52,6 +52,7 @@ class ModelLoader:
         vad_clip: bool = False,
         vad_clip_threshold: float = 0.5,
         vad_clip_pad_ms: int = 400,
+        vad_clip_libraries: Optional[Set[SttLibrary]] = None,
     ) -> None:
         self.preferred_stt_library = preferred_stt_library
         self.preferred_language = preferred_language
@@ -72,15 +73,26 @@ class ModelLoader:
         self.vad_clip = vad_clip
         self.vad_clip_threshold = vad_clip_threshold
         self.vad_clip_pad_ms = vad_clip_pad_ms
+        # None means every library when vad_clip is set; otherwise only these.
+        self.vad_clip_libraries = vad_clip_libraries
 
         self._transcriber: Dict[TRANSCRIBER_KEY, Transcriber] = {}
         self._transcriber_lock: Dict[TRANSCRIBER_KEY, asyncio.Lock] = defaultdict(
             asyncio.Lock
         )
+        self._stt_library: Dict[Optional[str], SttLibrary] = {}
 
-    async def load_transcriber(self, language: Optional[str] = None) -> Transcriber:
-        """Load or get transcriber from cache for a language."""
+    def resolve_stt_library(self, language: Optional[str] = None) -> SttLibrary:
+        """Resolve which speech-to-text library will be used for a language.
+
+        Cached per language: backend availability cannot change while running, and
+        callers (transcriber loading, the --vad-clip decision) ask repeatedly.
+        """
         language = language or self.preferred_language
+
+        cached = self._stt_library.get(language)
+        if cached is not None:
+            return cached
 
         # Detect which backends are installed *without* importing them. Importing
         # a backend loads its native libraries (sherpa-onnx, torch, onnxruntime,
@@ -119,6 +131,21 @@ class ModelLoader:
             has_funasr=has_funasr,
             has_qwen3_asr=has_qwen3_asr,
         )
+        self._stt_library[language] = stt_library
+        return stt_library
+
+    def should_vad_clip(self, language: Optional[str] = None) -> bool:
+        """Report whether leading/trailing silence should be clipped."""
+        return vad_clip_enabled(
+            self.resolve_stt_library(language),
+            self.vad_clip,
+            self.vad_clip_libraries,
+        )
+
+    async def load_transcriber(self, language: Optional[str] = None) -> Transcriber:
+        """Load or get transcriber from cache for a language."""
+        language = language or self.preferred_language
+        stt_library = self.resolve_stt_library(language)
 
         # Streaming is only supported by the sherpa backend.
         streaming = self.sherpa_streaming and (stt_library == SttLibrary.SHERPA)
@@ -231,6 +258,28 @@ class ModelLoader:
         _LOGGER.debug("Transcribed audio: %s", text)
 
         return text
+
+
+def vad_clip_enabled(
+    stt_library: SttLibrary,
+    vad_clip: bool,
+    vad_clip_libraries: Optional[Set[SttLibrary]] = None,
+) -> bool:
+    """Report whether --vad-clip applies to a resolved speech-to-text library.
+
+    `--vad-clip` with no values enables clipping for every library
+    (vad_clip_libraries is None); naming libraries restricts it to those, which is
+    useful because the benefit is backend-specific. Clipping is a clear win for
+    length-proportional backends (qwen3-asr, sherpa, funasr) and a wash for
+    faster-whisper, which pads audio to 30s internally regardless.
+    """
+    if not vad_clip:
+        return False
+
+    if vad_clip_libraries is None:
+        return True
+
+    return stt_library in vad_clip_libraries
 
 
 def guess_stt_library(


### PR DESCRIPTION
`--vad-clip` was all-or-nothing, but clipping silence is worth very different amounts depending on the backend. This makes it selectable:

```sh
--vad-clip                    # every library, as before
--vad-clip qwen3-asr          # only that one
--vad-clip qwen3-asr sherpa   # both
                              # absent -> disabled, as before
```

## Why

Qwen3-ASR costs **~235 ms per second of audio** on a Pi 5, and unusually *every* stage scales with input length:

| stage | per extra second |
|---|---|
| encoder | ~83 ms |
| decoder prefill | ~94 ms (13 more audio tokens/s in the prompt) |
| generation | ~55 ms (longer KV cache, so each decode step attends over more positions) |

Measured by padding `tests/turn-on-the-office-lamp.wav` with silence — 3.47 s → 1.361 s total, 11.47 s → 3.241 s, with the same 10-token transcript throughout. Even our "clean" test clip is only ~2 s of speech inside 3.47 s, so clipping saves ~330 ms against ~50–80 ms of VAD, roughly **20% off a typical command**.

faster-whisper gains nothing — it pads audio to 30 s internally regardless — which is exactly why turning clipping on globally was unattractive and it has stayed off by default.

## Implementation

The decision needs the *resolved* library, which `load_transcriber()` worked out privately. That resolution moves into `resolve_stt_library()`, memoized per language (backend availability can't change at runtime), and both callers now share one path. The predicate itself is a module-level pure function, `vad_clip_enabled()`, matching how `guess_stt_library()` is structured and tested.

`nargs="*"` with `choices` from the enum, so `--vad-clip bogus` is rejected at parse time. `auto` is excluded from the choices since it isn't a real backend — and because the check runs against the resolved library, `--stt-library auto --vad-clip qwen3-asr` behaves correctly per language.

## Testing

155 tests pass; `black`, `isort`, `flake8`, `mypy` clean, `pylint` 10/10 on `models.py`.

- Six unit tests on the predicate: off when absent, bare flag covers everything, named/unnamed, several names, and a defensive one that a stale library set can't enable clipping by itself
- Two in `test_dispatch_handler.py` covering the wiring: a library that wasn't named transcribes the untouched WAV, a named one actually reaches the clipper
- All four CLI forms verified end to end into `ModelLoader`

`FakeLoader` needed a `should_vad_clip`; it delegates to the real `vad_clip_enabled` rather than hardcoding a bool, so the fake can't drift from production logic. `FakeTranscriber` now also records `wav_path`, which is what makes the skip case assertable.

## Note

One incidental behaviour change: the "Backends available: …" debug line now logs once per language instead of once per request, since it sits inside the memoized resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)