### PR TITLE
Prepare 3.6.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install
         run: |
-          script/setup --dev --transformers
+          script/setup --dev --transformers --qwen3-asr --hass
 
       - name: Run tests
         run: script/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,24 @@
 # Changelog
 
-## Unreleased
+## 3.6.0
 
 - Add `--hass-token` (extra: `hass`) to bias transcription toward the names in Home Assistant: conversation-exposed entity names and aliases, plus area and floor names, read over the websocket API and passed to the model as a prompt (fixes e.g. "What's the temperature of the incubi?" → "What's the temperature of the Ecobee?")
-- Names are refreshed in the background starting at `AudioStart`, so the fetch finishes while the speaker is still talking and adds no latency; a slow or unreachable Home Assistant falls back to the previous names and never fails a transcript
-- Names are added to the prompt in priority order (areas, floors, entity names, aliases) up to `--hass-prompt-max-tokens` (default 200, Whisper's hard cap is 223); `--initial-prompt` is kept at the front
-- Add `--hass-api`, `--hass-refresh-seconds`, `--hass-prompt-max-tokens`, and `--hass-prompt-timeout`
-
-- Qwen3-ASR: support a merged decoder export (`decoder_merged.int4.onnx`) that takes a KV cache and a dynamic sequence length, so the biasing prompt's KV is computed once and reused instead of being re-prefilled every utterance. On a Pi 5 with a 50-name prompt, a 3.2s command goes from 3.42s to 2.20s (1.56x), peak RSS from 2.25 GB to 1.55 GB, and the package from 1407 MB to 785 MB
-- The merged layout is selected automatically when `decoder_merged.int4.onnx` is present; model directories with `decoder_init`/`decoder_step` keep working unchanged
-- The speedup applies to short commands. Long-form audio sees ~1.04x, since the cached prompt is a small share of the work — but the memory saving grows with length (4.16 GB → 2.87 GB on a 30s clip)
-- The default Qwen3-ASR model is now the merged export. On LibriSpeech test-other (n=200) it transcribes byte-identically to the split export with no prompt (5.35% WER for both), and scores 5.33% vs 5.43% with a 50-name prompt — a difference well inside sampling noise. Pass `--model rhasspy/qwen3-asr-0.6b-onnx-int4` for the split export, which stays published
+  - Names are refreshed in the background starting at `AudioStart`, so the fetch finishes while the speaker is still talking and adds no latency; a slow or unreachable Home Assistant falls back to the previous names and never fails a transcript
+  - Names are added to the prompt in priority order (areas, floors, entity names, aliases) up to `--hass-prompt-max-tokens` (default 200, Whisper's hard cap is 223); `--initial-prompt` is kept at the front
+  - Add `--hass-api`, `--hass-refresh-seconds`, `--hass-prompt-max-tokens`, and `--hass-prompt-timeout`
 
 - Add support for [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) via `--stt-library qwen3-asr` (extra: `qwen3_asr`), defaulting to [`rhasspy/qwen3-asr-0.6b-onnx-int4-merged`](https://huggingface.co/rhasspy/qwen3-asr-0.6b-onnx-int4-merged)
-- `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
-- Qwen3-ASR is opt-in only (`auto` never selects it): the model is 785 MB and needs ~1.6 GB of RAM, and it is slower than the per-language defaults
+  - `--initial-prompt` now also biases the Qwen3-ASR backend: it is passed as the model's context prompt, which corrects entity names (e.g. `Vocabulary: Ecobee.` turns "incubator" into "Ecobee")
+  - Qwen3-ASR is opt-in only (`auto` never selects it): the model is 785 MB and needs ~1.6 GB of RAM, and it is slower than the per-language defaults
+
+- Qwen3-ASR: support a merged decoder export (`decoder_merged.int4.onnx`) that takes a KV cache and a dynamic sequence length, so the biasing prompt's KV is computed once and reused instead of being re-prefilled every utterance. On a Pi 5 with a 50-name prompt, a 3.2s command goes from 3.42s to 2.20s (1.56x), peak RSS from 2.25 GB to 1.55 GB, and the package from 1407 MB to 785 MB
+  - The merged layout is selected automatically when `decoder_merged.int4.onnx` is present; model directories with `decoder_init`/`decoder_step` keep working unchanged
+  - The speedup applies to short commands. Long-form audio sees ~1.04x, since the cached prompt is a small share of the work — but the memory saving grows with length (4.16 GB → 2.87 GB on a 30s clip)
+  - The default Qwen3-ASR model is now the merged export. On LibriSpeech test-other (n=200) it transcribes byte-identically to the split export with no prompt (5.35% WER for both), and scores 5.33% vs 5.43% with a 50-name prompt — a difference well inside sampling noise. Pass `--model rhasspy/qwen3-asr-0.6b-onnx-int4` for the split export, which stays published
+
 - `--vad-clip` now takes optional speech-to-text libraries, so clipping can be enabled only where it pays off: `--vad-clip qwen3-asr` clips for that backend alone, while a bare `--vad-clip` still applies to every library. Qwen3-ASR costs ~235 ms per second of audio on a Pi 5 (encoder, prefill, *and* per-token decode all scale with input length), so trimming silence off a typical command saves ~20%; faster-whisper pads to 30s internally and gains nothing
+
+- The Docker image now includes the `qwen3-asr` and `hass` extras
 
 ## 3.5.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
     \
     && .venv/bin/pip3 install --no-cache-dir \
         --extra-index-url https://www.piwheels.org/simple \
-        -e '.[zeroconf,transformers,sherpa,onnx-asr]' \
+        -e '.[zeroconf,transformers,sherpa,onnx-asr,qwen3-asr,hass]' \
     \
     && rm -rf /var/lib/apt/lists/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyoming-faster-whisper"
-version = "3.5.0"
+version = "3.6.0"
 description = "Wyoming Server for Faster Whisper"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/script/setup
+++ b/script/setup
@@ -15,6 +15,15 @@ parser.add_argument(
 )
 parser.add_argument("--sherpa", action="store_true", help="Install sherpa requirements")
 parser.add_argument("--funasr", action="store_true", help="Install funasr requirements")
+parser.add_argument(
+    "--onnx-asr", action="store_true", help="Install onnx-asr requirements"
+)
+parser.add_argument(
+    "--qwen3-asr", action="store_true", help="Install qwen3-asr requirements"
+)
+parser.add_argument(
+    "--hass", action="store_true", help="Install Home Assistant requirements"
+)
 args = parser.parse_args()
 
 # Create virtual environment
@@ -39,6 +48,15 @@ if args.sherpa:
 
 if args.funasr:
     extras.append("funasr")
+
+if args.onnx_asr:
+    extras.append("onnx_asr")
+
+if args.qwen3_asr:
+    extras.append("qwen3_asr")
+
+if args.hass:
+    extras.append("hass")
 
 extras_str = ""
 if extras:

--- a/tests/test_dispatch_handler.py
+++ b/tests/test_dispatch_handler.py
@@ -21,8 +21,8 @@ from wyoming.audio import AudioChunk, AudioStart, AudioStop  # noqa: E402
 from wyoming.info import Info  # noqa: E402
 
 from wyoming_faster_whisper.const import (  # noqa: E402
-    SttLibrary,
     StreamingSession,
+    SttLibrary,
     Transcriber,
 )
 from wyoming_faster_whisper.dispatch_handler import DispatchEventHandler  # noqa: E402

--- a/tests/test_faster_whisper.py
+++ b/tests/test_faster_whisper.py
@@ -13,8 +13,7 @@ from wyoming.audio import AudioStart, AudioStop, wav_to_chunks
 from wyoming.event import async_read_event, async_write_event
 from wyoming.info import Describe, Info
 
-
-from . import _LOCAL_DIR, _SAMPLES_PER_CHUNK, _START_TIMEOUT, _TRANSCRIBE_TIMEOUT, _DIR
+from . import _DIR, _LOCAL_DIR, _SAMPLES_PER_CHUNK, _START_TIMEOUT, _TRANSCRIBE_TIMEOUT
 
 
 def _needs(module: str):


### PR DESCRIPTION
Release plumbing for 3.6.0. No functional changes to the server.

## Blockers for the release workflow

- **Bump version to 3.6.0.** `publish.yml` compares the pushed tag against `pyproject.toml` and exits if they differ.
- **Close the changelog section** (`## Unreleased` → `## 3.6.0`). The `changelog` job exits with "No changelog section found for 3.6.0" otherwise — and since it runs *after* the Docker push, the failure mode is a published image with no GitHub release.

Both were verified by running the workflow's own version check and release-notes extractor against this tree: pyproject reads `3.6.0` and the section extracts 17 lines of notes.

## `--hass-token` did not work in the Docker image

The image installed `.[zeroconf,transformers,sherpa,onnx-asr]`, so the `hass` extra was missing and `--hass-token` raised `ImportError` at startup — the release's headline feature could not run in `rhasspy/wyoming-whisper:3.6.0` at all. Added `hass` and `qwen3-asr` to the image.

Note that `qwen3-asr` pulls in `onnxruntime`, so the image grows; the 785 MB model itself is still downloaded to `/data` on first use, not baked in.

## CI was skipping the new tests

`test.yml` installed only `--dev --transformers`. All five new test files gate on `importorskip("aiohttp")` or the qwen3 handler, so roughly 1,400 lines of new tests were silently skipping on every PR. Now installs `--qwen3-asr --hass`, and `script/setup` has flags for those (plus `--onnx-asr`, which was missing already).

## Also

- Reordered the 3.6.0 changelog section so Qwen3-ASR is introduced before the merged-decoder bullets that build on it, and split the `--vad-clip` change out of that group. Detail bullets are nested, matching the 3.3.0 style. This text becomes the GitHub release notes verbatim.
- Fixed isort import ordering in `tests/test_dispatch_handler.py` (new this release) and `tests/test_faster_whisper.py` (pre-existing). `script/lint` only covers the module dir, so neither was caught.

## Verification

- Full suite: 155 passed, 2 xfailed
- `black`, `isort`, `flake8`, `mypy` clean; `pylint` 10.00/10

## Not addressed

Left out as out of scope, all pre-existing: the README never documents `--vad-clip` despite its syntax changing this release; `script/package` copies from a nonexistent `lib/` and would crash if run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
