### PR TITLE
Set any command-line option from the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Every command-line option can now also be set from the environment: `--some-option` reads `WYO_WHISPER_SOME_OPTION`, so a Compose stack can configure the container without rewriting its `command:` (#64, #112)
+  - Values can also come from a file named by `WYO_WHISPER_SOME_OPTION_FILE`, the Docker Compose/Swarm secrets convention, which keeps a long-lived Home Assistant token out of both the command line and the environment
+  - Precedence is command line, then `_FILE`, then the plain variable: an explicit argument is never silently overridden by a stale variable in a container
+  - Flags take `true`/`false` rather than being on whenever the variable exists, `--data-dir` splits on `:`, `--vad-clip` splits on commas or spaces, and values are checked against the option's type and choices with the variable named in the error
+  - A `WYO_WHISPER_` variable matching no option is warned about at startup instead of being ignored
+  - The Docker entrypoint drops its baked-in `--uri`, `--data-dir`, and `--device` defaults when the matching variable is set, since a command-line argument would otherwise always win over it
+
 - Home Assistant names now fill the prompt budget in four priority tiers: areas/floors that hold an exposed entity, then entity names in the domains people say out loud (`PRIORITY_DOMAINS`: light, switch, fan, media_player, climate, scene, todo), then the remaining areas/floors, then the remaining entity names
   - Aliases are no longer ranked below every name. An alias is what the speaker says *instead of* the entity's name, so each one now sits directly behind the name it belongs to and shares its tier — previously a home with enough areas and entities to fill the budget lost every alias
   - An entity's area is resolved through its device when it has no area of its own, so the device registry is read too — only when an exposed entity actually needs it

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ are used, or none at all, and the transcript still comes back.
 
 | Option | Default | Purpose |
 | --- | --- | --- |
-| `--hass-token` | | Long-lived access token. Enables everything above. |
+| `--hass-token` | | Long-lived access token. Enables everything above. Use `WYO_WHISPER_HASS_TOKEN_FILE` to keep it off the command line (see [Environment Variables](#environment-variables)). |
 | `--hass-api` | `http://homeassistant.local:8123/api` | Where to find Home Assistant. |
 | `--hass-refresh-seconds` | `0` | Minimum seconds between refreshes. `0` refreshes every utterance, so a rename takes effect immediately. |
 | `--hass-prompt-max-tokens` | `200` | Token budget for names. Whisper's hard cap is 223 and quality falls off before it. |
@@ -173,3 +173,72 @@ Notes and limits:
 
 If `--device cuda` produces no speedup, check the log: the server warns when the
 installed onnxruntime or sherpa-onnx build has no usable CUDA support.
+
+## Environment Variables
+
+Every command-line option can also be set from the environment, which is what
+Docker Compose gives you to configure a container without rewriting its
+`command:`. The variable is the option's name, uppercased, with dashes as
+underscores and a `WYO_WHISPER_` prefix:
+
+| Option | Variable |
+| --- | --- |
+| `--model` | `WYO_WHISPER_MODEL` |
+| `--language` | `WYO_WHISPER_LANGUAGE` |
+| `--stt-library` | `WYO_WHISPER_STT_LIBRARY` |
+| `--hass-token` | `WYO_WHISPER_HASS_TOKEN` |
+| ...and so on for every option in `--help` | |
+
+**Precedence**: a command-line argument always wins over the environment, so a
+variable left over in a container can never silently override an explicit
+argument. A variable that starts with `WYO_WHISPER_` but matches no option is
+reported at startup rather than ignored, so a typo doesn't leave the server
+running with a default you thought you had changed.
+
+A few options don't take a plain string on the command line, so they read one
+specially:
+
+- **Flags** (`--debug`, `--vad-filter`, `--local-files-only`, ...) take
+  `1`/`true`/`yes`/`on` or `0`/`false`/`no`/`off`/empty. Unlike a plain "is it
+  set?" test, `WYO_WHISPER_DEBUG=false` really does mean off.
+- **`--data-dir`**, which can be repeated, splits on `:` —
+  `WYO_WHISPER_DATA_DIR=/data:/media/models`. Passing any `--data-dir` on the
+  command line replaces the list rather than adding to it.
+- **`--vad-clip`**, which takes any number of values, splits on commas or
+  spaces. Empty means the flag with no values, i.e. every library.
+- **`--zeroconf`**, whose value is optional, takes the name to announce, or
+  empty for the default name.
+
+### Secrets
+
+Each variable also has a `_FILE` form naming a file to read the value out of:
+`WYO_WHISPER_HASS_TOKEN_FILE=/run/secrets/hass_token`. That is the convention
+Docker Compose and Swarm secrets use — a secret is mounted as a file rather than
+handed over as a variable — and it keeps a long-lived Home Assistant token out
+of both the process's command line and its environment. The file is preferred
+over the plain variable when both are set, and its trailing newline is stripped.
+
+```yaml
+services:
+  whisper:
+    image: rhasspy/wyoming-whisper
+    ports:
+      - "10300:10300"
+    volumes:
+      - ./data:/data
+    environment:
+      WYO_WHISPER_MODEL: tiny-int8
+      WYO_WHISPER_LANGUAGE: en
+      WYO_WHISPER_HASS_API: http://homeassistant.local:8123/api
+      WYO_WHISPER_HASS_TOKEN_FILE: /run/secrets/hass_token
+    secrets:
+      - hass_token
+
+secrets:
+  hass_token:
+    file: ./secrets/hass_token.txt
+```
+
+In the Docker image, `--uri`, `--data-dir`, and `--device` have defaults baked
+into the entrypoint; those are dropped when the matching variable is set, so
+`WYO_WHISPER_URI` and friends work there too.

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 cd /usr/src
 
+# Defaults for the image. Each is dropped when the matching WYO_WHISPER_* env
+# var is set, so `docker run -e WYO_WHISPER_URI=...` is not fighting an argument
+# that would always win over it.
+#
 # STT_DEVICE is set to "cuda" by Dockerfile.gpu and unset in the CPU image.
-# "$@" comes last so an explicit --device from the command line overrides it.
-.venv/bin/python3 -m wyoming_faster_whisper \
-    --uri 'tcp://0.0.0.0:10300' --data-dir '/data' \
-    --device "${STT_DEVICE:-cpu}" "$@"
+defaults=()
+[ -n "${WYO_WHISPER_URI}${WYO_WHISPER_URI_FILE}" ] ||
+    defaults+=(--uri 'tcp://0.0.0.0:10300')
+[ -n "${WYO_WHISPER_DATA_DIR}${WYO_WHISPER_DATA_DIR_FILE}" ] ||
+    defaults+=(--data-dir '/data')
+[ -n "${WYO_WHISPER_DEVICE}${WYO_WHISPER_DEVICE_FILE}" ] ||
+    defaults+=(--device "${STT_DEVICE:-cpu}")
+
+# "$@" comes last so an explicit argument from the command line overrides both.
+.venv/bin/python3 -m wyoming_faster_whisper "${defaults[@]}" "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "wyoming>=1.8,<2",
+    "wyoming>=1.10.2,<2",
     "faster-whisper>=1.2.1,<2",
     "pysilero-vad>=3.4.0,<4",
 ]

--- a/tests/test_env_args.py
+++ b/tests/test_env_args.py
@@ -1,0 +1,175 @@
+"""Tests for environment variable defaults."""
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+
+from wyoming_faster_whisper.__main__ import get_parser
+from wyoming_faster_whisper.const import SttLibrary
+from wyoming_faster_whisper.env_args import parse_args
+
+# Enough to satisfy the required options when the test is about something else.
+BASE_ARGS = ["--uri", "tcp://0.0.0.0:10300", "--data-dir", "/data"]
+
+
+def run(argv: Optional[Sequence[str]] = None, **environ: str) -> argparse.Namespace:
+    """Parse arguments with only the given environment."""
+    return parse_args(
+        get_parser(), BASE_ARGS if argv is None else argv, environ=environ
+    )
+
+
+def test_no_env_vars() -> None:
+    """Defaults are untouched when nothing is set."""
+    args = run()
+    assert args.uri == "tcp://0.0.0.0:10300"
+    assert args.data_dir == ["/data"]
+    assert args.device == "cpu"
+    assert args.beam_size == 0
+    assert not args.debug
+
+
+def test_required_arg_from_env() -> None:
+    """A required option no longer has to be on the command line."""
+    args = run([], WYO_WHISPER_URI="tcp://0.0.0.0:10301", WYO_WHISPER_DATA_DIR="/data")
+    assert args.uri == "tcp://0.0.0.0:10301"
+    assert args.data_dir == ["/data"]
+
+
+def test_required_arg_still_required(capsys: pytest.CaptureFixture) -> None:
+    """A required option with no variable set still fails."""
+    with pytest.raises(SystemExit):
+        run([])
+
+    assert "--uri" in capsys.readouterr().err
+
+
+def test_command_line_wins() -> None:
+    """An explicit argument is never shadowed by the environment."""
+    args = run(BASE_ARGS + ["--device", "cuda"], WYO_WHISPER_DEVICE="cpu")
+    assert args.device == "cuda"
+
+
+def test_type_conversion() -> None:
+    """Values go through the option's own type."""
+    args = run(WYO_WHISPER_BEAM_SIZE="3", WYO_WHISPER_VAD_THRESHOLD="0.25")
+    assert args.beam_size == 3
+    assert args.vad_threshold == 0.25
+
+
+def test_invalid_type(capsys: pytest.CaptureFixture) -> None:
+    """A value the option's type rejects is an error, not a crash."""
+    with pytest.raises(SystemExit):
+        run(WYO_WHISPER_BEAM_SIZE="large")
+
+    assert "WYO_WHISPER_BEAM_SIZE" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_flag_true(value: str) -> None:
+    """A flag can be turned on from the environment."""
+    assert run(WYO_WHISPER_DEBUG=value).debug
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_flag_false(value: str) -> None:
+    """A flag set to a false value stays off, unlike a plain truth test."""
+    assert not run(WYO_WHISPER_DEBUG=value).debug
+
+
+def test_flag_invalid(capsys: pytest.CaptureFixture) -> None:
+    """A flag set to something that is neither is an error."""
+    with pytest.raises(SystemExit):
+        run(WYO_WHISPER_VAD_FILTER="maybe")
+
+    assert "WYO_WHISPER_VAD_FILTER" in capsys.readouterr().err
+
+
+def test_append_arg() -> None:
+    """Repeatable options split on the path separator."""
+    data_dirs = os.pathsep.join(["/data", "/media/models"])
+    args = run(
+        [], WYO_WHISPER_URI="tcp://0.0.0.0:10300", WYO_WHISPER_DATA_DIR=data_dirs
+    )
+    assert args.data_dir == ["/data", "/media/models"]
+
+
+def test_append_arg_command_line_wins() -> None:
+    """Command-line values replace the environment's instead of adding to it."""
+    args = run(
+        ["--uri", "tcp://0.0.0.0:10300", "--data-dir", "/custom"],
+        WYO_WHISPER_DATA_DIR="/data",
+    )
+    assert args.data_dir == ["/custom"]
+
+
+def test_list_arg() -> None:
+    """An option taking several values splits on commas or spaces."""
+    args = run(WYO_WHISPER_VAD_CLIP="qwen3-asr, sherpa")
+    assert args.vad_clip == ["qwen3-asr", "sherpa"]
+
+
+def test_list_arg_empty() -> None:
+    """An empty value means the flag with no values (every library)."""
+    args = run(WYO_WHISPER_VAD_CLIP="")
+    assert args.vad_clip == []
+
+
+def test_optional_value_arg() -> None:
+    """An option with an optional value takes its constant when empty."""
+    assert run(WYO_WHISPER_ZEROCONF="").zeroconf == "faster-whisper"
+    assert run(WYO_WHISPER_ZEROCONF="kitchen").zeroconf == "kitchen"
+
+
+def test_choices_checked(capsys: pytest.CaptureFixture) -> None:
+    """A value outside the option's choices is an error."""
+    with pytest.raises(SystemExit):
+        run(WYO_WHISPER_STT_LIBRARY="not-a-library")
+
+    assert "WYO_WHISPER_STT_LIBRARY" in capsys.readouterr().err
+
+    args = run(WYO_WHISPER_STT_LIBRARY="sherpa")
+    assert SttLibrary(args.stt_library) == SttLibrary.SHERPA
+
+
+def test_secret_file(tmp_path: Path) -> None:
+    """A _FILE variable names a file to read the value out of."""
+    token_path = tmp_path / "hass_token"
+    token_path.write_text("s3cret\n", encoding="utf-8")
+
+    args = run(WYO_WHISPER_HASS_TOKEN_FILE=str(token_path))
+    assert args.hass_token == "s3cret"
+
+
+def test_secret_file_wins_over_plain_var(tmp_path: Path) -> None:
+    """The file is preferred: a stale plain variable cannot shadow the secret."""
+    token_path = tmp_path / "hass_token"
+    token_path.write_text("from-file", encoding="utf-8")
+
+    args = run(
+        WYO_WHISPER_HASS_TOKEN_FILE=str(token_path), WYO_WHISPER_HASS_TOKEN="from-env"
+    )
+    assert args.hass_token == "from-file"
+
+
+def test_secret_file_missing(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """An unreadable secret file fails loudly instead of starting unconfigured."""
+    with pytest.raises(SystemExit):
+        run(WYO_WHISPER_HASS_TOKEN_FILE=str(tmp_path / "missing"))
+
+    assert "WYO_WHISPER_HASS_TOKEN_FILE" in capsys.readouterr().err
+
+
+def test_unknown_var_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """A misspelled variable is reported instead of silently ignored."""
+    run(WYO_WHISPER_MODEL_NAME="tiny-int8")
+    assert "WYO_WHISPER_MODEL_NAME" in caplog.text
+
+
+def test_help_and_version_ignored() -> None:
+    """--help and --version take no value, so they get no variable."""
+    args = run(WYO_WHISPER_HELP="1", WYO_WHISPER_VERSION="1")
+    assert args.uri == "tcp://0.0.0.0:10300"

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -20,6 +20,8 @@ from .const import (
     SttLibrary,
 )
 from .dispatch_handler import DispatchEventHandler
+from .env_args import ENV_PREFIX
+from .env_args import parse_args as parse_args_with_env
 from .models import ModelLoader
 from .vocabulary import DEFAULT_PROMPT_MAX_TOKENS
 
@@ -30,9 +32,20 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-async def main() -> None:
-    """Main entry point."""
-    parser = argparse.ArgumentParser()
+def get_parser() -> argparse.ArgumentParser:
+    """Return the command-line parser.
+
+    Every option here also has an environment variable, so an argument added
+    below needs nothing extra to be settable from a container's environment.
+    """
+    parser = argparse.ArgumentParser(
+        epilog=(
+            "Every option can also be set from the environment: --some-option "
+            f"reads {ENV_PREFIX}SOME_OPTION, or {ENV_PREFIX}SOME_OPTION_FILE "
+            "to read the value out of a file (docker secrets). "
+            "Command-line arguments win over both."
+        )
+    )
     parser.add_argument("--uri", required=True, help="unix:// or tcp://")
     #
     parser.add_argument(
@@ -160,7 +173,8 @@ async def main() -> None:
     parser.add_argument(
         "--hass-token",
         help="Long-lived access token for Home Assistant. Enables biasing toward "
-        "the names of exposed entities, areas, and floors (extra: hass)",
+        "the names of exposed entities, areas, and floors (extra: hass). Keep it "
+        f"off the command line with {ENV_PREFIX}HASS_TOKEN_FILE",
     )
     parser.add_argument(
         "--hass-api",
@@ -199,7 +213,13 @@ async def main() -> None:
         version=__version__,
         help="Print version and exit",
     )
-    args = parser.parse_args()
+
+    return parser
+
+
+async def main() -> None:
+    """Main entry point."""
+    args = parse_args_with_env(get_parser())
 
     if not args.download_dir:
         # Download to first data dir by default

--- a/wyoming_faster_whisper/env_args.py
+++ b/wyoming_faster_whisper/env_args.py
@@ -1,0 +1,211 @@
+"""Environment variable defaults for the command-line options.
+
+Every ``--option`` of the server also reads ``WYO_WHISPER_OPTION``: the flag name
+uppercased, dashes as underscores, with a project-specific prefix so a compose
+stack shared with other Wyoming services cannot cross-configure this one.
+
+Values may also be placed in a file named by ``WYO_WHISPER_OPTION_FILE``, the
+convention Docker Compose and Swarm secrets use: a secret is mounted as a file
+under ``/run/secrets`` rather than delivered as a variable, so the variable
+points at the file instead. This keeps a long-lived Home Assistant token out of
+both the command line and the environment.
+
+Precedence is command line, then ``_FILE``, then the plain variable. An explicit
+flag always wins, so an argument can never be silently shadowed by a stale
+variable left over in a container.
+"""
+
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+ENV_PREFIX = "WYO_WHISPER_"
+FILE_SUFFIX = "_FILE"
+
+# Accepted spellings for flags like --debug, which take no value on the command
+# line and so need one invented for the environment.
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "no", "n", "off", ""}
+
+_LOGGER = logging.getLogger(__name__)
+
+# argparse offers no public way to walk a parser's options or to tell one kind of
+# action from another, and these names have been stable since argparse was added.
+# pylint: disable=protected-access
+_VALUELESS_ACTIONS = (argparse._HelpAction, argparse._VersionAction)
+_AppendAction = argparse._AppendAction
+_StoreConstAction = argparse._StoreConstAction
+# pylint: enable=protected-access
+
+# -----------------------------------------------------------------------------
+
+
+def env_var_name(dest: str) -> str:
+    """Return the environment variable that fills in an argument."""
+    return ENV_PREFIX + dest.upper()
+
+
+def parse_args(
+    parser: argparse.ArgumentParser,
+    argv: Optional[Sequence[str]] = None,
+    environ: Optional[Mapping[str, str]] = None,
+) -> argparse.Namespace:
+    """Parse arguments, falling back to the environment for missing options."""
+    if environ is None:
+        environ = os.environ
+
+    known_vars = set()
+
+    # Filled in after parsing so a command-line value replaces the environment's
+    # instead of being appended to it (see below).
+    append_defaults: Dict[str, List[Any]] = {}
+
+    for action in parser._actions:  # pylint: disable=protected-access
+        if isinstance(action, _VALUELESS_ACTIONS):
+            # --help/--version take no value
+            continue
+
+        if (not action.option_strings) or (action.dest == argparse.SUPPRESS):
+            continue
+
+        var_name = env_var_name(action.dest)
+        known_vars.add(var_name)
+
+        value = _read_env(parser, environ, var_name)
+        if value is None:
+            continue
+
+        default = _convert(parser, action, var_name, value)
+
+        if isinstance(action, _AppendAction):
+            append_defaults[action.dest] = default
+            action.default = None
+        else:
+            action.default = default
+
+        # The environment supplied it, so the command line does not have to.
+        action.required = False
+
+    args = parser.parse_args(argv)
+
+    for dest, default in append_defaults.items():
+        # argparse appends command-line values onto an action's default, which
+        # would merge the environment's list with the command line's. Only use
+        # the environment when the command line gave nothing.
+        if getattr(args, dest, None) is None:
+            setattr(args, dest, default)
+
+    _warn_unknown_vars(environ, known_vars)
+
+    return args
+
+
+# -----------------------------------------------------------------------------
+
+
+def _read_env(
+    parser: argparse.ArgumentParser, environ: Mapping[str, str], var_name: str
+) -> Optional[str]:
+    """Read a variable's value, preferring the file it may point at."""
+    file_path = environ.get(var_name + FILE_SUFFIX)
+    if file_path:
+        try:
+            # Trailing newlines are an artifact of writing the file, never part
+            # of a token or a URL.
+            return Path(file_path).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            parser.error(f"cannot read {var_name}{FILE_SUFFIX} ({file_path}): {exc}")
+
+    return environ.get(var_name)
+
+
+def _convert(
+    parser: argparse.ArgumentParser,
+    action: argparse.Action,
+    var_name: str,
+    value: str,
+) -> Any:
+    """Turn a variable's string into the value the action would have produced."""
+    if isinstance(action, _StoreConstAction):
+        # --debug and friends: the flag's presence is the value on the command
+        # line, so the variable has to spell out true or false. action.default
+        # is still the original one here.
+        return action.const if _to_bool(parser, var_name, value) else action.default
+
+    if isinstance(action, _AppendAction):
+        # Paths, which may contain spaces or commas, so only the platform's path
+        # separator splits them.
+        return [
+            _value(parser, action, var_name, item)
+            for item in value.split(os.pathsep)
+            if item
+        ]
+
+    if action.nargs in ("*", "+"):
+        items = [
+            _value(parser, action, var_name, item)
+            for item in re.split(r"[,\s]+", value.strip())
+            if item
+        ]
+        if (action.nargs == "+") and (not items):
+            parser.error(f"{var_name} needs at least one value")
+
+        return items
+
+    if (action.nargs == "?") and (action.const is not None) and (not value):
+        # An empty value means the flag with no value, e.g. --zeroconf
+        return action.const
+
+    return _value(parser, action, var_name, value)
+
+
+def _value(
+    parser: argparse.ArgumentParser,
+    action: argparse.Action,
+    var_name: str,
+    value: str,
+) -> Any:
+    """Apply the action's type conversion and check it against its choices."""
+    typed_value: Any = value
+    if callable(action.type):
+        try:
+            typed_value = action.type(value)
+        except (TypeError, ValueError) as exc:
+            parser.error(f"{var_name}: invalid value {value!r} ({exc})")
+
+    if (action.choices is not None) and (typed_value not in action.choices):
+        choices = ", ".join(str(choice) for choice in action.choices)
+        parser.error(f"{var_name}: {value!r} is not one of: {choices}")
+
+    return typed_value
+
+
+def _to_bool(parser: argparse.ArgumentParser, var_name: str, value: str) -> bool:
+    """Interpret a variable that stands in for a flag."""
+    normalized = value.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+
+    if normalized in _FALSE_VALUES:
+        return False
+
+    parser.error(f"{var_name}: {value!r} is not a true/false value")
+    raise AssertionError  # unreachable: parser.error exits
+
+
+def _warn_unknown_vars(environ: Mapping[str, str], known_vars: set) -> None:
+    """Warn about variables that look like options but match none of them.
+
+    A misspelled variable is otherwise silent: the server starts with a default
+    the user believed they had changed.
+    """
+    for name in sorted(environ):
+        if not name.startswith(ENV_PREFIX):
+            continue
+
+        base_name = name[: -len(FILE_SUFFIX)] if name.endswith(FILE_SUFFIX) else name
+        if base_name not in known_vars:
+            _LOGGER.warning("Ignoring unknown environment variable: %s", name)


### PR DESCRIPTION
Closes #64. Supersedes #112.

Two open PRs ask for the same thing from different ends: #64 wants every option settable from a `docker-compose.yml` without rewriting the container's `command:`, and #112 wants the Home Assistant token out of the command line and into a mounted secret. This does it once, generically, so an option added later needs nothing extra.

## What it does

Every `--some-option` also reads `WYO_WHISPER_SOME_OPTION`, derived from the argument's own `dest`. Values can also come from a file named by `WYO_WHISPER_SOME_OPTION_FILE` — the convention Compose and Swarm secrets use, since a secret is mounted as a file rather than handed over as a variable.

Precedence is **command line, then `_FILE`, then the plain variable**. An explicit argument always wins, so it can never be silently shadowed by a stale variable left in a container.

```yaml
services:
  whisper:
    image: rhasspy/wyoming-whisper
    environment:
      WYO_WHISPER_MODEL: tiny-int8
      WYO_WHISPER_LANGUAGE: en
      WYO_WHISPER_HASS_TOKEN_FILE: /run/secrets/hass_token
    secrets:
      - hass_token
```

## Why not just assign the variables as argparse defaults

That is what #64 does, and each of these is a way it goes wrong:

- **Required options.** `--uri` and `--data-dir` keep `required=True` there, so the variable is read and then argparse errors out anyway. Here `required` is cleared only for options the environment actually supplied, which keeps argparse's own error message for the rest.
- **Flags.** `default=os.environ.get(...)` makes `WYO_WHISPER_DEBUG=false` turn debug *on*, because any non-empty string is truthy. Flags take `1/true/yes/on` or `0/false/no/off`/empty, and anything else is an error.
- **`--data-dir`.** It is an `append` action, so a plain string default is both the wrong type and merged with whatever the command line adds. It splits on the path separator (`/data:/media/models`), and a command-line `--data-dir` replaces the list instead of appending to it.
- **Types and choices.** `WYO_WHISPER_BEAM_SIZE=5` stays the string `"5"` with a bare default; here values go through the option's own `type` and are checked against its `choices`, with the *variable* named in the error rather than the flag.
- **`--vad-clip`** splits on commas or spaces, and **`--zeroconf`** takes its const when empty.
- **Typos.** A `WYO_WHISPER_` variable matching no option is warned about at startup, instead of leaving the server running with a default the user thought they had changed.

## Prefix

`WYO_WHISPER_` rather than #64's `WYOMING_` or #112's bare `HASS_TOKEN`, per the review comment on #64: a Compose stack usually runs several Wyoming services, and a stray `HASS_TOKEN` in the environment would otherwise silently start this server calling the Home Assistant API. @DennisGaida — this covers #112's use case, with `WYO_WHISPER_HASS_TOKEN_FILE` in place of `HASS_TOKEN_FILE`.

## Docker

`docker_run.sh` drops each of its baked-in `--uri` / `--data-dir` / `--device` defaults when the matching variable is set, since a command-line argument would otherwise always win over it. With no variables set it passes exactly the same arguments as before, and `STT_DEVICE=cuda` from `Dockerfile.gpu` still works.

## Testing

28 tests in `tests/test_env_args.py` covering precedence, required options, flags, lists, append, types, choices, secret files and unknown variables — run against the real parser, which was extracted into `get_parser()`. `script/lint` (black, isort, flake8, pylint, mypy) is clean, and the 137 existing non-transcription tests pass. Also verified end to end that a server starts with `--uri` and `--data-dir` supplied only by the environment, and that the entrypoint builds the same argument list as before when no variables are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)