### PR TITLE
Prepare 3.7.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,35 +96,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Separate job so a failure here cannot hold back the CPU image, the wheel, or
-  # the release. amd64 only: there is no arm64 CUDA CTranslate2 wheel.
-  build_gpu:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build GPU image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.gpu
-          platforms: linux/amd64
-          push: true
-          tags: |
-            rhasspy/wyoming-whisper:gpu
-            rhasspy/wyoming-whisper:${{ needs.build.outputs.tag }}-gpu
-          cache-from: type=gha,scope=gpu
-          cache-to: type=gha,mode=max,scope=gpu
+  # Dockerfile.gpu is deliberately not built or published here. It comes out
+  # around 10.7 GB (mostly the CUDA torch wheel) versus ~1.6 GB for the CPU
+  # image, and Home Assistant OS has no GPU passthrough, so its whole audience
+  # is running Docker directly and can build it locally. See the README.
 
   changelog:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,23 @@
 # Changelog
 
-## Unreleased
+## 3.7.0
 
-- Every command-line option can now also be set from the environment: `--some-option` reads `WYO_WHISPER_SOME_OPTION`, so a Compose stack can configure the container without rewriting its `command:` (#64, #112)
+- Every command-line option can now also be set from the environment: `--some-option` reads `WYO_WHISPER_SOME_OPTION`, so a Compose stack can configure the container without rewriting its `command:` (#64 by @ffeliziani-tpmc, #112 by @DennisGaida)
   - Values can also come from a file named by `WYO_WHISPER_SOME_OPTION_FILE`, the Docker Compose/Swarm secrets convention, which keeps a long-lived Home Assistant token out of both the command line and the environment
   - Precedence is command line, then `_FILE`, then the plain variable: an explicit argument is never silently overridden by a stale variable in a container
   - Flags take `true`/`false` rather than being on whenever the variable exists, `--data-dir` splits on `:`, `--vad-clip` splits on commas or spaces, and values are checked against the option's type and choices with the variable named in the error
-  - A `WYO_WHISPER_` variable matching no option is warned about at startup instead of being ignored
+  - A `WYO_WHISPER_` variable matching no option is warned about at startup instead of being ignored, and one left empty means the same as not setting it — except for the three that give empty a meaning of their own (a flag is off, `--vad-clip` is every library, `--zeroconf` is the default name)
   - The Docker entrypoint drops its baked-in `--uri`, `--data-dir`, and `--device` defaults when the matching variable is set, since a command-line argument would otherwise always win over it
 
 - Home Assistant names now fill the prompt budget in four priority tiers: areas/floors that hold an exposed entity, then entity names in the domains people say out loud (`PRIORITY_DOMAINS`: light, switch, fan, media_player, climate, scene, todo), then the remaining areas/floors, then the remaining entity names
   - Aliases are no longer ranked below every name. An alias is what the speaker says *instead of* the entity's name, so each one now sits directly behind the name it belongs to and shares its tier — previously a home with enough areas and entities to fill the budget lost every alias
   - An entity's area is resolved through its device when it has no area of its own, so the device registry is read too — only when an exposed entity actually needs it
   - In a home that overruns the budget, this stops exposed-by-the-hundred sensors and empty areas from crowding out the lights, scenes and media players a command names
-- Add a `gpu` Docker tag (`Dockerfile.gpu`) that runs faster-whisper, transformers, onnx-asr, and qwen3-asr on an NVIDIA GPU: CUDA torch plus `onnxruntime-gpu` on a CUDA 12.8 / cuDNN 9 base. `--device cuda` is the default there; `docker run --gpus all` and the NVIDIA Container Toolkit are required (the image carries the same extras as the CPU one, so FunASR is still not included in either)
+- Add `Dockerfile.gpu`, a CUDA variant of the image that runs faster-whisper, transformers, onnx-asr, and qwen3-asr on an NVIDIA GPU: CUDA torch plus `onnxruntime-gpu` on a CUDA 12.8 / cuDNN 9 base. `--device cuda` is the default there; `docker run --gpus all` and the NVIDIA Container Toolkit are required (it carries the same extras as the CPU image, so FunASR is still not included in either) (#76 by @lmoe)
+  - **Build it yourself** — this one is not published to Docker Hub. It comes out around 10.7 GB, mostly the CUDA torch wheel, against ~1.6 GB for the CPU image, and Home Assistant OS offers no GPU passthrough, so everyone who can use it is already running Docker directly. `docker build -f Dockerfile.gpu -t wyoming-whisper:gpu .` — see the README
   - NVIDIA and amd64 only. CTranslate2 (faster-whisper) has no ROCm or XPU backend and no arm64 CUDA wheel, which is what bounds the image; the torch-based backends alone would work elsewhere
   - `--stt-library sherpa` stays on the CPU there. sherpa-onnx bundles its own onnxruntime, and two CUDA-enabled onnxruntime builds in one process segfault — reachable via `--stt-library auto`, which routes English to sherpa and Russian to onnx-asr. sherpa's default models are int8, which the CUDA provider gains little on, so the CPU wheel is the better half of the trade
-- `--device` now reaches every backend, not just faster-whisper and FunASR. `transformers` moves the model to the device and runs float16 there, `sherpa` selects the CUDA provider, and `onnx-asr`/`qwen3-asr` select the CUDA execution provider with a CPU fallback. `cuda:N` selects a specific GPU
+- `--device` now reaches every backend, not just faster-whisper and FunASR. `transformers` moves the model to the device and runs float16 there, `sherpa` selects the CUDA provider, and `onnx-asr`/`qwen3-asr` select the CUDA execution provider with a CPU fallback. `cuda:N` selects a specific GPU (#87 by @zackify)
   - Previously `--device cuda` was silently ignored by four of the six backends
 - On CUDA, `--compute-type` defaults to `float16` rather than the model's own type, and the auto-selected faster-whisper model is `Systran/faster-whisper-small` (float16) rather than an int8 conversion
 - `sherpa` now locates its model files by prefix instead of hard-coding `*.int8.onnx`, and prefers an fp32 graph over int8 when running on the GPU with a model that ships both

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,12 @@
-# CUDA variant of the CPU image in ./Dockerfile, published as the "gpu" tag.
+# CUDA variant of the CPU image in ./Dockerfile.
+#
+# Not published to Docker Hub - build it locally:
+#
+#   docker build -f Dockerfile.gpu -t wyoming-whisper:gpu .
+#
+# It comes out around 10.7 GB (mostly the CUDA torch wheel) against ~1.6 GB for
+# the CPU image, and Home Assistant OS has no GPU passthrough, so its entire
+# audience is already running Docker directly.
 #
 # amd64 only, and NVIDIA only: CTranslate2 (faster-whisper) has no ROCm or XPU
 # backend and no arm64 CUDA wheel, so it is the constraint that decides the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Clone the repository and set up Python virtual environment:
 
 ``` sh
-git clone https://github.com/rhasspy/wyoming-faster-whisper.git
+git clone https://github.com/OHF-Voice/wyoming-faster-whisper.git
 cd wyoming-faster-whisper
 script/setup
 ```
@@ -136,13 +136,25 @@ docker run -it -p 10300:10300 -v /path/to/local/data:/data rhasspy/wyoming-whisp
 
 ### GPU Image
 
-The `gpu` tag runs the speech-to-text backends on an NVIDIA GPU. It needs the
+`Dockerfile.gpu` runs the speech-to-text backends on an NVIDIA GPU. **It is not
+published to Docker Hub — you build it yourself**, because it comes out around
+10.7 GB (mostly the CUDA torch wheel) against ~1.6 GB for the CPU image, and
+Home Assistant OS has no GPU passthrough, so everyone who can use it is already
+running Docker directly.
+
+``` sh
+git clone https://github.com/OHF-Voice/wyoming-faster-whisper.git
+cd wyoming-faster-whisper
+docker build -f Dockerfile.gpu -t wyoming-whisper:gpu .
+```
+
+Running it needs the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 on the host, and `--gpus`:
 
 ``` sh
 docker run -it --gpus all -p 10300:10300 -v /path/to/local/data:/data \
-    rhasspy/wyoming-whisper:gpu --language en
+    wyoming-whisper:gpu --language en
 ```
 
 `--device cuda` is the default in this image; pass `--device cuda:1` to pick a
@@ -152,7 +164,7 @@ CPU, and a GPU can comfortably run much larger ones:
 
 ``` sh
 docker run -it --gpus all -p 10300:10300 -v /path/to/local/data:/data \
-    rhasspy/wyoming-whisper:gpu --model Systran/faster-whisper-large-v3 --language en
+    wyoming-whisper:gpu --model Systran/faster-whisper-large-v3 --language en
 ```
 
 Notes and limits:
@@ -160,11 +172,9 @@ Notes and limits:
 - **NVIDIA and amd64 only.** CTranslate2, which faster-whisper is built on, has
   no ROCm or Intel XPU backend and publishes no arm64 CUDA wheel. The
   torch-based backends (`--stt-library transformers`, `--stt-library funasr`)
-  would work on ROCm or XPU, but that would be a different image, not this tag.
-- **The image is large** (~10.7 GB, mostly the CUDA torch wheel) versus ~1.6 GB
-  for the CPU image. Don't pull it onto a Pi by accident.
-- **Home Assistant OS provides no GPU passthrough**, so this tag is for
-  standalone Docker/Compose users rather than the add-on.
+  would work on ROCm or XPU, but that would be a different image.
+- **Budget the disk.** ~10.7 GB for the image, plus build cache. Don't build it
+  on a Pi by accident.
 - **`--stt-library sherpa` runs on the CPU even in this image.** A CUDA
   sherpa-onnx build exists, but sherpa-onnx bundles its own onnxruntime, and two
   CUDA-enabled onnxruntime builds in one process segfault. Its default Parakeet
@@ -173,6 +183,23 @@ Notes and limits:
 
 If `--device cuda` produces no speedup, check the log: the server warns when the
 installed onnxruntime or sherpa-onnx build has no usable CUDA support.
+
+### GPU Without Docker
+
+For a local install rather than a container, the two onnxruntime-based backends
+have GPU counterparts of their extras — `onnx-asr-gpu` and `qwen3-asr-gpu`,
+which pull `onnxruntime-gpu` in place of `onnxruntime`:
+
+``` sh
+pip install 'wyoming-faster-whisper[transformers,onnx-asr-gpu,qwen3-asr-gpu]'
+```
+
+faster-whisper additionally needs a CUDA-enabled CTranslate2 and torch built for
+your CUDA version, and it depends on `onnxruntime` (for its bundled Silero VAD),
+which will pull the CPU package back in and clobber `onnxruntime-gpu` — both
+install the same `onnxruntime` module and whichever lands second wins, silently,
+since the CPU provider still loads every model. Reinstall `onnxruntime-gpu`
+last. `Dockerfile.gpu` does exactly this and is the working reference.
 
 ## Environment Variables
 
@@ -208,6 +235,11 @@ specially:
   spaces. Empty means the flag with no values, i.e. every library.
 - **`--zeroconf`**, whose value is optional, takes the name to announce, or
   empty for the default name.
+
+Any other variable left empty means the same as not setting it at all, which is
+what a compose file or a `.env` produces for a value whose author left it blank.
+An empty `WYO_WHISPER_URI` gets you argparse's "the following arguments are
+required", not a server that starts up and fails on an empty string.
 
 ### Secrets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wyoming-faster-whisper"
-version = "3.6.0"
+version = "3.7.0"
 description = "Wyoming Server for Faster Whisper"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "http://github.com/rhasspy/wyoming-faster-whisper"
+Homepage = "https://github.com/OHF-Voice/wyoming-faster-whisper"
 
 [tool.setuptools]
 platforms = ["any"]

--- a/tests/test_env_args.py
+++ b/tests/test_env_args.py
@@ -106,6 +106,45 @@ def test_append_arg_command_line_wins() -> None:
     assert args.data_dir == ["/custom"]
 
 
+def test_empty_required_var_is_unset(capsys: pytest.CaptureFixture) -> None:
+    """An empty variable does not satisfy a required option.
+
+    A blank value in a compose file or a .env has to mean the same as not
+    setting it, so argparse reports the missing option instead of the server
+    starting with an empty string and failing further in.
+    """
+    with pytest.raises(SystemExit):
+        run([], WYO_WHISPER_URI="", WYO_WHISPER_DATA_DIR="/data")
+
+    assert "--uri" in capsys.readouterr().err
+
+    with pytest.raises(SystemExit):
+        run([], WYO_WHISPER_URI="tcp://0.0.0.0:10300", WYO_WHISPER_DATA_DIR="")
+
+    assert "--data-dir" in capsys.readouterr().err
+
+
+def test_empty_optional_var_keeps_default() -> None:
+    """An empty variable leaves an optional option on its default."""
+    args = run(WYO_WHISPER_DEVICE="", WYO_WHISPER_MODEL="", WYO_WHISPER_HASS_TOKEN="")
+    assert args.device == "cpu"
+    assert args.model == "auto"
+    assert args.hass_token is None
+
+
+def test_whitespace_only_var_is_unset() -> None:
+    """A variable holding only whitespace is empty too."""
+    assert run(WYO_WHISPER_DEVICE="   ").device == "cpu"
+
+
+def test_empty_secret_file_is_unset(tmp_path: Path) -> None:
+    """An empty secret file does not enable the feature it would configure."""
+    token_path = tmp_path / "hass_token"
+    token_path.write_text("\n", encoding="utf-8")
+
+    assert run(WYO_WHISPER_HASS_TOKEN_FILE=str(token_path)).hass_token is None
+
+
 def test_list_arg() -> None:
     """An option taking several values splits on commas or spaces."""
     args = run(WYO_WHISPER_VAD_CLIP="qwen3-asr, sherpa")

--- a/wyoming_faster_whisper/env_args.py
+++ b/wyoming_faster_whisper/env_args.py
@@ -75,7 +75,7 @@ def parse_args(
         known_vars.add(var_name)
 
         value = _read_env(parser, environ, var_name)
-        if value is None:
+        if (value is None) or _is_unset(action, value):
             continue
 
         default = _convert(parser, action, var_name, value)
@@ -104,6 +104,35 @@ def parse_args(
 
 
 # -----------------------------------------------------------------------------
+
+
+def _is_unset(action: argparse.Action, value: str) -> bool:
+    """Report whether an empty variable means "not set" for this option.
+
+    ``WYO_WHISPER_DATA_DIR=`` with nothing after it is what a compose file or a
+    ``.env`` produces for a value the author left blank, and it has to mean the
+    same thing as not writing the line at all. Otherwise it satisfies argparse's
+    required check while supplying nothing, and the server dies later on an
+    empty string or an empty list rather than on argparse's own "the following
+    arguments are required".
+
+    Three kinds of option give an empty value a meaning of its own, and keep it:
+    a flag reads it as false, ``--vad-clip`` as "every library", and
+    ``--zeroconf`` as "the default name".
+    """
+    if value.strip():
+        return False
+
+    if isinstance(action, _StoreConstAction):
+        return False  # --debug= is off, not unset
+
+    if action.nargs in ("*", "+"):
+        return False  # --vad-clip= is the flag with no values
+
+    if (action.nargs == "?") and (action.const is not None):
+        return False  # --zeroconf= is the flag with its default name
+
+    return True
 
 
 def _read_env(


### PR DESCRIPTION
Release prep for 3.7.0.

## Required by the release workflow

`pyproject.toml` to 3.7.0 and the changelog's `## Unreleased` retitled to
`## 3.7.0`. Both are hard gates in `publish.yml` — `read_ver` fails the tag if
pyproject disagrees, and the `changelog` job exits 3 if no heading matches. I
ran both checks locally against these files and they pass.

## Contributor credits

Three bullets now carry attribution, matching the style used through 3.3.0:
#64 (@ffeliziani-tpmc) and #112 (@DennisGaida) for the environment variables,
#76 (@lmoe) for the CUDA image, #87 (@zackify) for the sherpa CUDA provider.
All four are closed as superseded, with a comment explaining what replaced them.

## The GPU image is no longer built or pushed

`build_gpu` is removed from `publish.yml`. It's ~10.7 GB against ~1.6 GB for the
CPU image, and Home Assistant OS has no GPU passthrough, so its entire audience
is running Docker directly and can build it locally. That also retires an
untested risk: the job had never once run — the release workflow last executed
at v3.6.0, before `Dockerfile.gpu` existed — so tagging would have been its
first execution, building a 10.7 GB image on a runner with ~14 GB free and
exporting `mode=max` into a 10 GB repo-wide cache budget.

`Dockerfile.gpu` itself is unchanged apart from its header comment. The README's
GPU section is rewritten around `docker build` instead of a published tag, and
gains a **GPU Without Docker** section — the `onnx-asr-gpu` and `qwen3-asr-gpu`
extras existed in pyproject but appeared in no documentation, despite `--device`
telling users to "see README".

## Empty environment variables are unset

A blank value in a compose file or `.env` satisfied argparse's required check
while supplying nothing:

```
WYO_WHISPER_DATA_DIR=""  ->  data_dir=[]  ->  data_dir[0]  ->  IndexError
WYO_WHISPER_URI=""       ->  uri=''       ->  AsyncServer.from_uri('')
```

Now it means the same as not setting the line at all, so you get argparse's "the
following arguments are required" instead of a traceback further in. The three
options that give empty a meaning of its own keep it — a flag is off,
`--vad-clip` is every library, `--zeroconf` is the default name — and there are
tests pinning each. An empty `_FILE` secret is unset too, so a blank token file
no longer enables HA biasing with an empty token.

Only the Docker entrypoint was immune, since its `-n` test already treated empty
as unset; this only ever bit bare pip installs.

## Also

Homepage and README clone URL point at OHF-Voice rather than rhasspy.

## Verification

`226 passed, 2 xfailed` (4 new). black, isort, flake8 clean; pylint 10.00/10;
mypy clean.

## After merge

Tag `v3.7.0` on the merge commit to trigger the release. Issue #115 is left open
deliberately — it asks for the `gpu` tag, and closing it before 3.7.0 exists
would point someone at a README section they can't read yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
