### PR TITLE
Warn when prompting a Distil-Whisper model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Warn at startup when `--initial-prompt` or `--hass-token` is used with a Distil-Whisper model, and document that these models are not compatible with prompting (#118 by @jfoxwoosh)
+  - Distil-Whisper was distilled without previous-text conditioning, so a prompt never helps it. `distil-small.en` is actively damaged: from about 52 prompt tokens on, `avg_logprob` drops below faster-whisper's -1.0 threshold, every temperature fails, and output that was correct unprompted comes back truncated (`Start a timer for 25 minutes` → `Start a timer.`) or looping (`Add Hot Dog, Hot Dog, Hot Dog, …`). Whether the transcript ends up wrong or empty then depends on `no_speech_prob` for that utterance
+  - `distil-large-v3` is inert rather than broken — stable at every prompt size, but with no biasing effect either, still returning `EcoBe` with `Ecobee` in the prompt
+  - The prompt is still sent, since the damage is size-dependent and a short `--initial-prompt` may be harmless. Standard Whisper models are unaffected: `small.en` is steady through a 97-token prompt and biasing works as intended there
+
 ## 3.7.0
 
 - Every command-line option can now also be set from the environment: `--some-option` reads `WYO_WHISPER_SOME_OPTION`, so a Compose stack can configure the container without rewriting its `command:` (#64 by @ffeliziani-tpmc, #112 by @DennisGaida)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ script/run --model tiny-int8 --language en --uri 'tcp://0.0.0.0:10300' --data-di
 ```
 
 The `--model` can also be a HuggingFace model like `Systran/faster-distil-whisper-small.en`
+(but see [Distil-Whisper models are not compatible](#distil-whisper-models-are-not-compatible)
+if you want name biasing)
 
 **NOTE**: Models are downloaded to the first `--data-dir` directory.
 
@@ -94,6 +96,25 @@ prompt, ahead of anything discovered from Home Assistant.
 
 This biases `faster-whisper` and `qwen3-asr`, the backends that take a prompt.
 Others ignore it.
+
+### Distil-Whisper models are not compatible
+
+Distil-Whisper checkpoints (`Systran/faster-distil-whisper-*`, `distil-small.en`,
+`distil-large-v3`, …) were distilled without previous-text conditioning, so a
+prompt is at best wasted on them and at worst destroys the transcription. This
+applies to `--initial-prompt` as much as to `--hass-token`; the server warns at
+startup and sends the prompt anyway, since a very short one may be harmless.
+
+Measured on the same clean commands, comparing no prompt against a 29-name
+(~97-token) list:
+
+| Model | With a prompt |
+| --- | --- |
+| `small.en` | Works as intended: `Natalie Sparkly` → `Natalie's Heart Light` |
+| `distil-small.en` | Breaks from ~52 prompt tokens on: `avg_logprob` falls below -1.0, every temperature fails, output truncates (`Start a timer for 25 minutes` → `Start a timer.`) or loops (`Add Hot Dog, Hot Dog, Hot Dog, …`) |
+| `distil-large-v3` | Inert. No collapse at any size, but no biasing either — `Ecobee` still comes back `EcoBe` with the name in the prompt |
+
+Use a standard Whisper model to bias toward your names.
 
 ### Prompt cost on qwen3-asr
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from wyoming_faster_whisper.const import SttLibrary
 from wyoming_faster_whisper.models import (
     guess_model,
     guess_stt_library,
+    is_distil_whisper,
     vad_clip_enabled,
 )
 
@@ -194,3 +195,48 @@ def test_other_backends_keep_the_same_default_model_on_gpu(library) -> None:
         assert guess_model(library, language, is_arm=False, gpu=True) == guess_model(
             library, language, is_arm=False
         )
+
+
+# --- Distil-Whisper detection ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "Systran/faster-distil-whisper-small.en",
+        "Systran/faster-distil-whisper-large-v3",
+        "distil-small.en",
+        "distil-whisper/distil-large-v3",
+        "DISTIL-SMALL.EN",  # case-insensitive
+    ],
+)
+def test_distil_models_are_detected(model) -> None:
+    assert is_distil_whisper(model)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        None,  # --model auto never resolves to a distil checkpoint
+        "tiny-int8",
+        "small.en",
+        "Systran/faster-whisper-large-v3",
+        "openai/whisper-tiny.en",
+    ],
+)
+def test_standard_models_are_not_detected(model) -> None:
+    assert not is_distil_whisper(model)
+
+
+def test_every_default_model_takes_a_prompt() -> None:
+    # A guessed model must never be one that biasing cannot work with.
+    for library in SttLibrary:
+        if library == SttLibrary.AUTO:
+            continue
+
+        for language in ("en", "de", "ru", "zh", None):
+            for is_arm in (False, True):
+                for gpu in (False, True):
+                    assert not is_distil_whisper(
+                        guess_model(library, language, is_arm=is_arm, gpu=gpu)
+                    )

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -22,7 +22,7 @@ from .const import (
 from .dispatch_handler import DispatchEventHandler
 from .env_args import ENV_PREFIX
 from .env_args import parse_args as parse_args_with_env
-from .models import ModelLoader
+from .models import ModelLoader, is_distil_whisper
 from .vocabulary import DEFAULT_PROMPT_MAX_TOKENS
 
 if TYPE_CHECKING:
@@ -325,6 +325,8 @@ async def main() -> None:
         vad_clip_libraries=vad_clip_libraries,
     )
 
+    _warn_if_prompt_unsupported(args, loader)
+
     # Load model
     _LOGGER.debug("Pre-loading transcriber")
     await loader.load_transcriber()
@@ -358,6 +360,32 @@ async def main() -> None:
 
 
 # -----------------------------------------------------------------------------
+
+
+def _warn_if_prompt_unsupported(args: argparse.Namespace, loader: ModelLoader) -> None:
+    """Warn when a prompt is being sent to a model that cannot handle one.
+
+    Distil-Whisper checkpoints degrade rather than benefit: the prompt truncates
+    or derails the transcription instead of biasing it. The prompt is still sent
+    -- this only warns -- because the damage is size-dependent and a very short
+    --initial-prompt may be harmless.
+    """
+    if not (args.initial_prompt or args.hass_token):
+        return
+
+    if loader.resolve_stt_library() != SttLibrary.FASTER_WHISPER:
+        return
+
+    if not is_distil_whisper(args.model):
+        return
+
+    _LOGGER.warning(
+        "Model '%s' is a Distil-Whisper model, which is not compatible with "
+        "prompting: --initial-prompt and --hass-token/--hass-api will degrade "
+        "transcription instead of improving it. Use a standard Whisper model "
+        "for name biasing.",
+        args.model,
+    )
 
 
 async def _load_names(args: argparse.Namespace) -> Optional["HassNameCache"]:

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -300,6 +300,20 @@ def vad_clip_enabled(
     return stt_library in vad_clip_libraries
 
 
+def is_distil_whisper(model: Optional[str]) -> bool:
+    """Report whether a model id names a Distil-Whisper checkpoint.
+
+    Distil-Whisper was distilled without previous-text conditioning, so prompt
+    context never helps it. `distil-small.en` is actively damaged: a 52-token
+    prompt pushes avg_logprob below -1.0 and yields truncated or looping output
+    on audio it transcribes perfectly unprompted. `distil-large-v3` is instead
+    inert -- stable at every prompt size, but with no biasing effect either.
+    Nothing in the CTranslate2 config identifies a distilled checkpoint, so the
+    model id is the only signal available.
+    """
+    return (model is not None) and ("distil" in model.lower())
+
+
 def guess_stt_library(
     preferred_stt_library: SttLibrary,
     model: Optional[str],


### PR DESCRIPTION
Closes #118.

The reporter found that enabling `--hass-api`/`--hass-token` produced no transcripts at all, with faster-whisper logging a failed log-probability threshold at every temperature — and that it only happened on a distil model. Both halves check out.

## What's going on

Distil-Whisper was distilled without previous-text conditioning, so prompt context puts its decoder off-distribution. Measured against `small.en` as a control, on clean command audio, comparing no prompt to a 29-name (~97-token) list:

| prompt | `distil-small.en` | `small.en` |
| --- | --- | --- |
| none | `What is the temperature of the equilibrium?` (lp -0.44) | `…of the ecobee?` (lp -0.51) |
| 12 names / 37 tok | `…of the Eco-Bee?` (lp -0.42) | `…of the ecobee?` (lp -0.29) |
| 16 names / 53 tok | `…of the eco-bee?  Be,` (lp **-1.30**, T=1.0) | `…of the ecobee?` (lp -0.29) |
| 29 names / 99 tok | `What is the,  Be.` (lp **-1.10**, T=1.0) | `…of the ecobee?` (lp -0.31) |

`distil-small.en` falls off a cliff between 37 and 53 prompt tokens: `avg_logprob` crosses faster-whisper's -1.0 threshold, all six temperatures fail, and output degenerates into truncation or repetition loops:

```
' Start, for, for, for, for, for, for, for, for, for, for, for, for…'
' Add Hot Dog, Hot Dog, Hot Dog, Hot Dog, regret, Hot Dog Hot Dog To AD…'
```

Whether the user then sees garbage or *nothing* depends on `no_speech_prob` for that utterance: a segment is skipped outright when `no_speech_prob > 0.6` and the `avg_logprob > -1.0` rescue no longer applies (`faster_whisper/transcribe.py`, `generate_segments`). That's the empty transcript in #118.

It isn't only prompt length — every prompt shape hurts `distil-small.en`. A 65-token prose prompt still drops the duration from `start a timer for 25 minutes`, and the gentlest shape tested (51 tokens of example sentences) still turns `Natalie's heart light` into `Natalie's heart`. So shrinking `--hass-prompt-max-tokens` or rewording the prompt only moves the cliff.

`distil-large-v3` is a different failure: flat across every size (22→99 tokens) and shape, no temperature fallback anywhere, `avg_logprob` moving only -0.27 → -0.33 — but no biasing either. `Ecobee` is in the prompt and it still writes `EcoBe` at 99 tokens; `Natalie's heartlight` never becomes `Natalie's Heart Light`. Both clips where there was room to show a win, and non-distil `small.en` fixes both.

## The change

Warn at startup, and document the incompatibility. The prompt is still sent, since the damage is size-dependent and a short `--initial-prompt` may well be harmless.

- `is_distil_whisper()` in `models.py` — a substring check on the model id. Nothing in the CTranslate2 `config.json` identifies a distilled checkpoint, so the id is the only signal available at load time.
- `_warn_if_prompt_unsupported()` in `__main__.py`, called before the transcriber loads. Fires only when a prompt is actually in play (`--initial-prompt` or `--hass-token`) and the resolved backend is faster-whisper, so a sherpa model with "distil" in its name won't trip it.
- README gets a "Distil-Whisper models are not compatible" section under the biasing docs, linked from the `--model` example that suggests `Systran/faster-distil-whisper-small.en`.

Note this applies to plain `--initial-prompt` too, and always has — it predates name biasing. Biasing just made it fire on every utterance, with the comma-list shape that happens to be the worst case.

## Verification

Live, with `--initial-prompt`:

```
WARNING:__main__:Model 'Systran/faster-distil-whisper-small.en' is a Distil-Whisper
model, which is not compatible with prompting: --initial-prompt and
--hass-token/--hass-api will degrade transcription instead of improving it.
Use a standard Whisper model for name biasing.
INFO:__main__:Ready
```

Silent without a prompt. Tests cover detection both ways, plus `test_every_default_model_takes_a_prompt`, which asserts `guess_model` never returns a distil checkpoint for any library/language/arch/GPU combination — the assumption that makes checking `args.model` sound.

237 passed, 2 xfailed; lint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)