### PR TITLE
Add a Docker health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add a Docker health check to both images, matching the one in wyoming-piper 2.4.3 (#119 by @netsho)
+  - It sends the server a `Describe` and requires an `Info` with an ASR program back, rather than only opening a socket: the port is bound by the OS, so a connect-only check stays green even when the event loop is wedged, while a round trip proves the accept loop and the event handler are both still running
+  - `--start-period` is 5 minutes, since the server only starts listening once the model is loaded — which means downloading it on first run — and it takes 3 consecutive failures to turn the container unhealthy, because transcription runs on the event loop and a check can time out behind a long request
+  - The URI to check follows `WYO_WHISPER_URI` (or its `_FILE` form) when the container sets it, with a listen-everywhere host like `0.0.0.0` rewritten to loopback. A `--uri` passed to `docker run` instead is invisible to it, so pass the same one to `python3 -m wyoming_faster_whisper.health_check --uri ...`
+
 - Warn at startup when `--initial-prompt` or `--hass-token` is used with a Distil-Whisper model, and document that these models are not compatible with prompting (#118 by @jfoxwoosh)
   - Distil-Whisper was distilled without previous-text conditioning, so a prompt never helps it. `distil-small.en` is actively damaged: from about 52 prompt tokens on, `avg_logprob` drops below faster-whisper's -1.0 threshold, every temperature fails, and output that was correct unprompted comes back truncated (`Start a timer for 25 minutes` → `Start a timer.`) or looping (`Add Hot Dog, Hot Dog, Hot Dog, …`). Whether the transcript ends up wrong or empty then depends on `no_speech_prob` for that utterance
   - `distil-large-v3` is inert rather than broken — stable at every prompt size, but with no biasing effect either, still returning `EcoBe` with `Ecobee` in the prompt

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,12 @@ COPY ./ ./
 
 EXPOSE 10300
 
+# The server only starts listening once the model is loaded, which means
+# downloading it on first run -- hence the long start period, during which
+# failures don't count against --retries. --retries covers the other direction:
+# transcription runs on the event loop, so a check can time out behind a long
+# request without the server being unhealthy.
+HEALTHCHECK --interval=30s --timeout=20s --start-period=5m --retries=3 \
+    CMD ["/usr/src/.venv/bin/python3", "-m", "wyoming_faster_whisper.health_check"]
+
 ENTRYPOINT ["bash", "docker_run.sh"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -80,4 +80,9 @@ ENV STT_DEVICE=cuda \
 
 EXPOSE 10300
 
+# See the CPU image for why this is a Describe/Info round trip and why the start
+# period is this long.
+HEALTHCHECK --interval=30s --timeout=20s --start-period=5m --retries=3 \
+    CMD ["/usr/src/.venv/bin/python3", "-m", "wyoming_faster_whisper.health_check"]
+
 ENTRYPOINT ["bash", "docker_run.sh"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,44 @@ docker run -it -p 10300:10300 -v /path/to/local/data:/data rhasspy/wyoming-whisp
 
 [Source](https://github.com/rhasspy/wyoming-addons/tree/master/whisper)
 
+### Health Check
+
+Both images carry a `HEALTHCHECK`, so `docker ps` reports `healthy` or
+`unhealthy` and a Compose stack can wait on it with `depends_on:` /
+`condition: service_healthy`. It sends the server a `Describe` and requires an
+`Info` with an ASR program back, rather than only opening a socket: the port is
+bound by the OS, so a connect-only check stays green even when the event loop is
+wedged, while a round trip proves the accept loop and the event handler are both
+still running.
+
+The first 5 minutes don't count against it, because the server only starts
+listening once the model is loaded — which means downloading it on first run —
+and it takes 3 consecutive failures to turn the container unhealthy, because
+transcription runs on the event loop and a check can time out behind a long
+request.
+
+To run it by hand:
+
+``` sh
+docker exec whisper \
+    /usr/src/.venv/bin/python3 -m wyoming_faster_whisper.health_check
+```
+
+It prints nothing and exits 0 when healthy, or prints `unhealthy: <reason>` and
+exits 1. That reason is what `docker inspect` shows under `.State.Health`.
+
+The URI it checks is `tcp://127.0.0.1:10300`, or `WYO_WHISPER_URI` when the
+container sets one (a listen-everywhere host like `0.0.0.0` is rewritten to
+loopback). A `--uri` passed to `docker run` instead of the variable is invisible
+to the check, so give it the same one:
+
+```yaml
+    healthcheck:
+      test: ["CMD", "/usr/src/.venv/bin/python3", "-m",
+             "wyoming_faster_whisper.health_check",
+             "--uri", "tcp://127.0.0.1:10400"]
+```
+
 ### GPU Image
 
 `Dockerfile.gpu` runs the speech-to-text backends on an NVIDIA GPU. **It is not

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,247 @@
+"""Tests for the Docker health check.
+
+Runs the check against a real socket rather than a mocked client, since what it
+is meant to prove is that a Describe gets an Info back over the wire.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator, Awaitable, Callable, Optional
+
+import pytest
+from wyoming.asr import Transcript
+from wyoming.event import Event, async_read_event, async_write_event
+from wyoming.info import AsrProgram, Attribution, Describe, Info
+
+from wyoming_faster_whisper.health_check import DEFAULT_URI, check, default_uri, main
+
+Responder = Callable[[Event, asyncio.StreamWriter], Awaitable[bool]]
+
+INFO = Info(
+    asr=[
+        AsrProgram(
+            name="faster-whisper",
+            description="Faster Whisper transcription with CTranslate2",
+            attribution=Attribution(name="Test", url="http://example.com"),
+            installed=True,
+            version="1.0.0",
+            models=[],
+        )
+    ]
+)
+
+# -----------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def fake_server(respond: Responder) -> AsyncIterator[str]:
+    """Serve on a random port with a handler of the test's choosing."""
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while True:
+                event = await async_read_event(reader)
+                if (event is None) or (not await respond(event, writer)):
+                    break
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handle, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        yield f"tcp://127.0.0.1:{port}"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def _describe_responder(
+    event: Event, writer: asyncio.StreamWriter, info: Optional[Info] = INFO
+) -> bool:
+    """Answer Describe with info, like the real server does."""
+    if Describe.is_type(event.type):
+        await async_write_event((info or INFO).event(), writer)
+
+    return True
+
+
+@asynccontextmanager
+async def hanging_server() -> AsyncIterator[str]:
+    """Serve a socket that accepts a connection and then never answers."""
+    release = asyncio.Event()
+
+    async def respond(event: Event, writer: asyncio.StreamWriter) -> bool:
+        await release.wait()
+        return False
+
+    async with fake_server(respond) as uri:
+        try:
+            yield uri
+        finally:
+            # Let the handler return: wait_closed() blocks until it does.
+            release.set()
+
+
+async def unused_uri() -> str:
+    """Return a URI for a port that nothing is listening on."""
+    async with fake_server(_describe_responder) as uri:
+        pass
+
+    return uri
+
+
+# -----------------------------------------------------------------------------
+
+
+async def test_check_succeeds() -> None:
+    """A server that answers Describe with ASR programs is healthy."""
+    async with fake_server(_describe_responder) as uri:
+        await check(uri)
+
+
+async def test_check_skips_unexpected_events() -> None:
+    """Anything that isn't Info is ignored rather than failing the check."""
+
+    async def respond(event: Event, writer: asyncio.StreamWriter) -> bool:
+        if Describe.is_type(event.type):
+            await async_write_event(Transcript(text="surprise").event(), writer)
+            await async_write_event(INFO.event(), writer)
+
+        return True
+
+    async with fake_server(respond) as uri:
+        await check(uri)
+
+
+async def test_check_fails_without_asr_programs() -> None:
+    """Info with no ASR programs means the server came up without a backend."""
+
+    async def respond(event: Event, writer: asyncio.StreamWriter) -> bool:
+        return await _describe_responder(event, writer, info=Info(asr=[]))
+
+    async with fake_server(respond) as uri:
+        with pytest.raises(RuntimeError, match="No ASR programs"):
+            await check(uri)
+
+
+async def test_check_fails_when_connection_closes() -> None:
+    """A socket that accepts and then hangs up is not healthy."""
+
+    async def respond(event: Event, writer: asyncio.StreamWriter) -> bool:
+        return False  # disconnect without answering
+
+    async with fake_server(respond) as uri:
+        with pytest.raises(RuntimeError, match="Connection closed"):
+            await check(uri)
+
+
+async def test_check_fails_when_nothing_is_listening() -> None:
+    """Nothing bound to the port at all."""
+    with pytest.raises(OSError):
+        await check(await unused_uri())
+
+
+async def test_check_hangs_until_the_timeout() -> None:
+    """A server that accepts but never answers is caught by --timeout, not hung on."""
+    async with hanging_server() as uri:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(check(uri), timeout=0.1)
+
+
+# -----------------------------------------------------------------------------
+
+
+async def test_main_exits_zero_when_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The module Docker runs succeeds quietly."""
+    async with fake_server(_describe_responder) as uri:
+        monkeypatch.setattr("sys.argv", ["health_check", "--uri", uri])
+        await main()
+
+
+async def test_main_exits_one_when_unhealthy(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Docker only sees the exit status, so the reason has to be printed."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["health_check", "--uri", await unused_uri(), "--timeout", "5"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await main()
+
+    assert exc_info.value.code == 1
+    assert "unhealthy:" in capsys.readouterr().err
+
+
+async def test_main_reports_a_timeout_by_name(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """TimeoutError has an empty message, which would print nothing useful."""
+    async with hanging_server() as uri:
+        monkeypatch.setattr(
+            "sys.argv", ["health_check", "--uri", uri, "--timeout", "0.1"]
+        )
+
+        with pytest.raises(SystemExit):
+            await main()
+
+    assert "unhealthy: TimeoutError" in capsys.readouterr().err
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_default_uri_is_loopback() -> None:
+    """Nothing in the environment: the image's own port."""
+    assert default_uri({}) == DEFAULT_URI
+
+
+def test_default_uri_follows_the_environment() -> None:
+    """A container that moved the port moved it with WYO_WHISPER_URI."""
+    assert (
+        default_uri({"WYO_WHISPER_URI": "tcp://127.0.0.1:10400"})
+        == "tcp://127.0.0.1:10400"
+    )
+
+
+@pytest.mark.parametrize(
+    ("listen_uri", "expected"),
+    [
+        ("tcp://0.0.0.0:10400", "tcp://127.0.0.1:10400"),
+        ("tcp://[::]:10400", "tcp://[::1]:10400"),
+        ("unix:///tmp/whisper.socket", "unix:///tmp/whisper.socket"),
+    ],
+)
+def test_default_uri_rewrites_wildcard_hosts(listen_uri: str, expected: str) -> None:
+    """The server's listen-everywhere host is not an address to connect to.
+
+    0.0.0.0 reaches the local host on Linux, but "::" does not, and neither is
+    guaranteed to elsewhere. unix:// is passed through untouched.
+    """
+    assert default_uri({"WYO_WHISPER_URI": listen_uri}) == expected
+
+
+def test_default_uri_ignores_an_empty_variable() -> None:
+    """Empty means unset, the same as it does for the server's options."""
+    assert default_uri({"WYO_WHISPER_URI": "  "}) == DEFAULT_URI
+
+
+def test_default_uri_reads_the_file_form(tmp_path: Path) -> None:
+    """Every option has a _FILE form; the trailing newline is not part of it."""
+    uri_path = tmp_path / "uri"
+    uri_path.write_text("tcp://0.0.0.0:10400\n", encoding="utf-8")
+
+    assert (
+        default_uri({"WYO_WHISPER_URI_FILE": str(uri_path)}) == "tcp://127.0.0.1:10400"
+    )
+
+
+def test_default_uri_survives_an_unreadable_file(tmp_path: Path) -> None:
+    """A bad _FILE is the server's error to report, not a stat traceback here."""
+    assert default_uri({"WYO_WHISPER_URI_FILE": str(tmp_path / "missing")}) == (
+        DEFAULT_URI
+    )

--- a/wyoming_faster_whisper/health_check.py
+++ b/wyoming_faster_whisper/health_check.py
@@ -1,0 +1,133 @@
+"""Health check for the Wyoming server.
+
+Used by the Dockerfile's HEALTHCHECK. Asking for info rather than just opening a
+socket is deliberate: the port is bound by the OS, so a connect-only check stays
+green even if the event loop is wedged. A Describe/Info round trip proves the
+accept loop and the event handler are both still running.
+
+Only imports wyoming and this package's environment-variable names, so it stays
+fast and does not depend on the optional extras or on a backend being
+importable.
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Mapping, Optional
+from urllib.parse import urlparse, urlunparse
+
+from wyoming.client import AsyncClient
+from wyoming.info import Describe, Info
+
+from .env_args import ENV_PREFIX, FILE_SUFFIX
+
+DEFAULT_URI = "tcp://127.0.0.1:10300"
+
+# What a server binds to when it means "every interface". These are addresses to
+# listen on, not addresses to connect to: 0.0.0.0 happens to reach the local
+# host on Linux, but "::" does not, and an empty host is not a host at all.
+_WILDCARD_HOSTS = {"0.0.0.0": "127.0.0.1", "::": "::1", "": "127.0.0.1"}
+
+
+async def check(uri: str) -> None:
+    """Ask the server for its info, or raise."""
+    async with AsyncClient.from_uri(uri) as client:
+        await client.write_event(Describe().event())
+
+        while True:
+            event = await client.read_event()
+            if event is None:
+                raise RuntimeError("Connection closed without info")
+
+            if Info.is_type(event.type):
+                info = Info.from_event(event)
+                if not info.asr:
+                    raise RuntimeError("No ASR programs in info")
+
+                return
+
+            # The server sends nothing else in response to Describe, but skip
+            # anything unexpected instead of failing on it.
+
+
+def default_uri(environ: Optional[Mapping[str, str]] = None) -> str:
+    """Return the URI to check, following the server's own configuration.
+
+    The image's entrypoint only supplies its baked-in ``--uri`` when
+    ``WYO_WHISPER_URI`` is unset, so that variable is where a container's port
+    differs from the default. A ``--uri`` passed to ``docker run`` instead is
+    invisible here; pass the same one to this check.
+    """
+    if environ is None:
+        environ = os.environ
+
+    return _to_loopback(_configured_uri(environ) or DEFAULT_URI)
+
+
+def _configured_uri(environ: Mapping[str, str]) -> Optional[str]:
+    """Read WYO_WHISPER_URI, preferring the file it may point at."""
+    file_path = environ.get(f"{ENV_PREFIX}URI{FILE_SUFFIX}")
+    if file_path:
+        try:
+            return Path(file_path).read_text(encoding="utf-8").strip() or None
+        except OSError:
+            # The server reports this one at startup; here it would only turn a
+            # readable "unhealthy: connection refused" into a stat error.
+            return None
+
+    return (environ.get(f"{ENV_PREFIX}URI") or "").strip() or None
+
+
+def _to_loopback(uri: str) -> str:
+    """Rewrite a listen-everywhere host into one that can be connected to."""
+    parsed = urlparse(uri)
+    if parsed.scheme != "tcp":
+        return uri
+
+    host = _WILDCARD_HOSTS.get(parsed.hostname or "")
+    if host is None:
+        return uri
+
+    if ":" in host:
+        host = f"[{host}]"  # IPv6 literals are bracketed in a URI
+
+    port = f":{parsed.port}" if parsed.port else ""
+
+    return urlunparse(parsed._replace(netloc=f"{host}{port}"))
+
+
+async def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--uri",
+        default=default_uri(),
+        help="unix:// or tcp:// (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="Seconds to wait for info (default: 15)",
+    )
+    args = parser.parse_args()
+
+    try:
+        await asyncio.wait_for(check(args.uri), timeout=args.timeout)
+    except Exception as err:  # pylint: disable=broad-except
+        # Docker only reports the exit status, so the reason has to be printed.
+        # It shows up in "docker inspect" as the health check's output.
+        # TimeoutError, among others, has an empty message, so fall back to the
+        # class name.
+        print(f"unhealthy: {str(err) or type(err).__name__}", file=sys.stderr)
+        sys.exit(1)
+
+
+def run() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Fixes #119.

Ports the health check from [wyoming-piper 2.4.3](https://github.com/OHF-Voice/wyoming-piper/blob/master/wyoming_piper/health_check.py), with `info.asr` in place of `info.tts`.

A `Describe`/`Info` round trip rather than a socket connect: the port is bound by the OS, so a connect-only check stays green even when the event loop is wedged, while a round trip proves the accept loop and the event handler are both still running. The module only imports `wyoming` and this package's environment-variable names, so it stays fast and doesn't depend on the optional extras or on a backend being importable.

`HEALTHCHECK` goes in both images with piper's timings — `--start-period=5m` because the server only starts listening once the model is loaded, which means downloading it on first run, and `--retries=3` because transcription runs on the event loop and a check can time out behind a long request.

## One difference from piper

The URI to check follows `WYO_WHISPER_URI` (and its `_FILE` form) when the container sets one, falling back to `tcp://127.0.0.1:10300`. Without that, the check would be permanently red for anyone who used the documented environment-variable config to move the port — this image advertises that path in the README, piper's doesn't.

A listen-everywhere host is rewritten to loopback (`0.0.0.0` → `127.0.0.1`, `::` → `::1`), since that's what the variable normally holds and `::` isn't connectable. `unix://` passes through untouched.

A `--uri` passed to `docker run` instead of the variable is invisible to the check; the README says so and shows the Compose override.

## Verification

Built the CPU image and ran it, rather than only testing in-process.

- **Healthy** — container with `--model tiny-int8 --language en` reached `Status: healthy`, `ExitCode: 0`, empty output, 115 ms per check.
- **Unhealthy** — a container whose server never starts flipped to `Up 12 seconds (unhealthy)`, with the reason where `docker inspect` shows it: `"Output": "unhealthy: [Errno 111] Connect call failed ('127.0.0.1', 10300)\n"`.
- **`WYO_WHISPER_URI`** — a container run with `-e WYO_WHISPER_URI=tcp://0.0.0.0:10400` went healthy on its own. Negative control inside that same container: the baked-in default (`:10300`) reports `unhealthy: [Errno 111] Connect call failed`, so the env handling is load-bearing rather than accidentally passing. `WYO_WHISPER_URI_FILE` exits 0 too.

17 new tests in `tests/test_health_check.py` drive `check()` and `main()` over real sockets — healthy, empty `asr`, hang-up, nothing listening, timeout reported by class name, non-`Info` events skipped — plus the URI-default cases. Full suite: 254 passed, 2 xfailed. black/isort/flake8/pylint 10.00/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
