### PR TITLE
Load cached models without contacting the hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Models that are already downloaded now load without contacting Hugging Face, so a server with no route to the internet starts instead of boot-looping (#93 by @schuylermartin45, #92)
+  - Loading is cache-first by default: each backend is built with `local_files_only` and only retried as a download when a file is genuinely missing. The hub check is what fails without internet, not the model load, and on a network that drops outbound traffic rather than refusing it — a Docker bridge marked `internal` — it stalled for the full TCP timeout on every start
+  - `--local-files-only` still means what it says: no fallback, so a model that isn't cached is an error rather than a surprise download. It had no effect at all on faster-whisper, the default backend, which never received the flag
+  - FunASR ignored `--download-dir` entirely, putting its ~900 MB of models in `~/.cache/huggingface` instead, and reported a failed download as `model ... is not registered` several steps later. Its model directory is now resolved before FunASR is handed the model
+  - Sherpa models, which come from GitHub releases rather than the hub, are covered too
+- Both Docker images set `HF_HOME`, `XDG_CACHE_HOME`, and `MODELSCOPE_CACHE` to `/data` so the caches that no command-line option reaches also land on the volume
+  - The Xet chunk cache used during hub downloads (`$HF_HOME/xet`) is the big one: several GB, previously written to the container's filesystem
+  - It also fixes the unwritable `/.cache` that a container running as a uid with no passwd entry would hit, since `$HOME` is unset there
+
 - Add a Docker health check to both images, matching the one in wyoming-piper 2.4.3 (#119 by @netsho)
   - It sends the server a `Describe` and requires an `Info` with an ASR program back, rather than only opening a socket: the port is bound by the OS, so a connect-only check stays green even when the event loop is wedged, while a round trip proves the accept loop and the event handler are both still running
   - `--start-period` is 5 minutes, since the server only starts listening once the model is loaded — which means downloading it on first run — and it takes 3 consecutive failures to turn the container unhealthy, because transcription runs on the event loop and a check can time out behind a long request

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,20 @@ RUN \
 
 COPY ./ ./
 
+# Keep every cache on the /data volume instead of the container's filesystem.
+# Model files already go there (--download-dir defaults to the first --data-dir),
+# but the libraries also write caches that no per-call argument reaches: the Xet
+# chunk cache used during hub downloads is $HF_HOME/xet and can run to several
+# GB, and torch/others fall back to $XDG_CACHE_HOME. Unset, all of that lands in
+# $HOME/.cache - which is thrown away on every container recreate, and is an
+# unwritable /.cache when the container runs as a uid with no passwd entry.
+#
+# These have to be environment variables: huggingface_hub reads them into
+# constants at import time, so setting them from Python would be too late.
+ENV HF_HOME=/data \
+    XDG_CACHE_HOME=/data \
+    MODELSCOPE_CACHE=/data/modelscope
+
 EXPOSE 10300
 
 # The server only starts listening once the model is loaded, which means

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -74,9 +74,15 @@ COPY ./ ./
 
 # docker_run.sh reads STT_DEVICE; an explicit --device on the command line still
 # wins, since user arguments are appended after it.
+#
+# HF_HOME/XDG_CACHE_HOME/MODELSCOPE_CACHE keep the library caches on the /data
+# volume; see the CPU image for why they have to be set here and not in Python.
 ENV STT_DEVICE=cuda \
     NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    HF_HOME=/data \
+    XDG_CACHE_HOME=/data \
+    MODELSCOPE_CACHE=/data/modelscope
 
 EXPOSE 10300
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,45 @@ docker run -it -p 10300:10300 -v /path/to/local/data:/data rhasspy/wyoming-whisp
 
 [Source](https://github.com/rhasspy/wyoming-addons/tree/master/whisper)
 
+### Running Without Internet Access
+
+A model that is already downloaded is loaded from disk without contacting
+Hugging Face, so a container that has been started once keeps working on a
+network with no route out. Only a model that is *missing* is fetched.
+
+That matters on a network which drops outbound traffic rather than refusing it —
+a Docker bridge marked `internal`, for example. The update check that used to
+run on every start would sit there until the TCP connection timed out, and with
+`restart: always` the container boot-looped.
+
+To rule out downloads entirely, pass `--local-files-only` (or
+`WYO_WHISPER_LOCAL_FILES_ONLY=true`) once the models you want are in `/data`. A
+model that is not there is then an error instead of a download:
+
+```yaml
+services:
+  whisper:
+    image: rhasspy/wyoming-whisper
+    volumes:
+      - ./data:/data
+    environment:
+      WYO_WHISPER_MODEL: tiny-int8
+      WYO_WHISPER_LANGUAGE: en
+      WYO_WHISPER_LOCAL_FILES_ONLY: "true"
+    networks:
+      - no-internet
+
+networks:
+  no-internet:
+    internal: true
+```
+
+Both images point `HF_HOME`, `XDG_CACHE_HOME`, and `MODELSCOPE_CACHE` at `/data`
+so the caches these libraries keep outside the model directory land on the
+volume too. The largest is the Xet chunk cache used while downloading, which can
+run to several GB. Outside Docker, set them yourself if you don't want them in
+`~/.cache`.
+
 ### Health Check
 
 Both images carry a `HEALTHCHECK`, so `docker ps` reports `healthy` or

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ import pytest
 
 from wyoming_faster_whisper.const import SttLibrary
 from wyoming_faster_whisper.models import (
+    ModelLoader,
     guess_model,
     guess_stt_library,
     is_distil_whisper,
@@ -240,3 +241,83 @@ def test_every_default_model_takes_a_prompt() -> None:
                     assert not is_distil_whisper(
                         guess_model(library, language, is_arm=is_arm, gpu=gpu)
                     )
+
+
+# --- cache-first loading --------------------------------------------------
+
+
+def _loader(**kwargs) -> ModelLoader:
+    """Build a ModelLoader with the arguments the cache-first path cares about."""
+    return ModelLoader(
+        preferred_stt_library=SttLibrary.FASTER_WHISPER,
+        preferred_language="en",
+        download_dir="/data",
+        local_files_only=kwargs.pop("local_files_only", False),
+        model="Systran/faster-whisper-base",
+        compute_type="default",
+        device="cpu",
+        beam_size=5,
+        cpu_threads=4,
+        initial_prompt=None,
+        vad_parameters=None,
+        **kwargs,
+    )
+
+
+def _record_attempts(loader: ModelLoader, fail_cached: bool) -> list:
+    """Replace backend construction with a recorder of local_files_only values."""
+    attempts: list = []
+
+    def build(stt_library, model, streaming, local_files_only):
+        attempts.append(local_files_only)
+        if local_files_only and fail_cached:
+            # What huggingface_hub raises for a cache miss.
+            raise FileNotFoundError("not cached")
+
+        return f"transcriber(local_files_only={local_files_only})"
+
+    loader._build_transcriber = build  # type: ignore[method-assign]
+    return attempts
+
+
+@pytest.mark.asyncio
+async def test_cached_model_is_loaded_without_the_hub() -> None:
+    # The common case: the model is on disk, so nothing should reach the network
+    # even though --local-files-only was not passed.
+    loader = _loader()
+    attempts = _record_attempts(loader, fail_cached=False)
+
+    assert await loader.load_transcriber() == "transcriber(local_files_only=True)"
+    assert attempts == [True]
+
+
+@pytest.mark.asyncio
+async def test_missing_model_falls_back_to_downloading() -> None:
+    loader = _loader()
+    attempts = _record_attempts(loader, fail_cached=True)
+
+    assert await loader.load_transcriber() == "transcriber(local_files_only=False)"
+    assert attempts == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_local_files_only_does_not_fall_back() -> None:
+    # Explicitly asking for offline means a missing model is an error, not a
+    # download.
+    loader = _loader(local_files_only=True)
+    attempts = _record_attempts(loader, fail_cached=True)
+
+    with pytest.raises(FileNotFoundError):
+        await loader.load_transcriber()
+
+    assert attempts == [True]
+
+
+@pytest.mark.asyncio
+async def test_transcriber_is_only_built_once() -> None:
+    loader = _loader()
+    attempts = _record_attempts(loader, fail_cached=True)
+
+    first = await loader.load_transcriber()
+    assert await loader.load_transcriber() is first
+    assert attempts == [True, False]

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -167,7 +167,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--local-files-only",
         action="store_true",
-        help="Don't check HuggingFace hub for updates every time",
+        help="Never download a model: fail if it isn't already in --download-dir "
+        "(cached models are loaded without a download regardless)",
     )
     # Home Assistant name biasing (extra: hass)
     parser.add_argument(

--- a/wyoming_faster_whisper/faster_whisper_handler.py
+++ b/wyoming_faster_whisper/faster_whisper_handler.py
@@ -19,6 +19,7 @@ class FasterWhisperTranscriber(Transcriber):
         self,
         model_id: str,
         cache_dir: Union[str, Path],
+        local_files_only: bool = False,
         device: str = "cpu",
         compute_type: str = "default",
         cpu_threads: int = 4,
@@ -39,6 +40,7 @@ class FasterWhisperTranscriber(Transcriber):
         self.model = faster_whisper.WhisperModel(
             model_id,
             download_root=str(cache_dir),
+            local_files_only=local_files_only,
             device=ct2_device,
             compute_type=compute_type,
             cpu_threads=cpu_threads,

--- a/wyoming_faster_whisper/funasr_handler.py
+++ b/wyoming_faster_whisper/funasr_handler.py
@@ -1,7 +1,6 @@
 """Code for transcription using the FunASR library."""
 
 import contextlib
-import os
 import sys
 import wave
 from pathlib import Path
@@ -13,7 +12,9 @@ from typing import Optional, Union
 # onnx_asr_handler/transformers_whisper.
 import numpy as np
 from funasr import AutoModel
+from funasr.download.name_maps_from_hub import name_maps_hf
 from funasr.utils.postprocess_utils import rich_transcription_postprocess
+from huggingface_hub import snapshot_download
 
 from .const import Transcriber, sense_voice_language
 from .device import torch_device
@@ -32,22 +33,41 @@ class FunASRTranscriber(Transcriber):
         device: str = "cpu",
     ) -> None:
         """Initialize model."""
-        # FunASR (hub="hf") downloads via huggingface_hub; honor the cache dir.
-        os.environ.setdefault("HF_HOME", str(Path(cache_dir).resolve()))
-        if local_files_only:
-            # FunASR's AutoModel has no local_files_only flag; gate downloads
-            # via the huggingface_hub environment variable instead.
-            os.environ.setdefault("HF_HUB_OFFLINE", "1")
-
         self._postprocess = rich_transcription_postprocess
         self._is_sense_voice = "SenseVoice" in model_id
+
+        # Resolve the model directory before handing it to FunASR. Left to
+        # itself, FunASR calls snapshot_download(model) with no arguments of its
+        # own -- so the model lands in the default hub cache rather than
+        # cache_dir -- and then swallows any download error ("Download: ...
+        # failed!") before failing later with an unrelated "model is not
+        # registered". Downloading here keeps the files where they belong and
+        # lets a cache miss surface as the LocalEntryNotFoundError that
+        # ModelLoader needs to see. Passing a directory skips FunASR's own
+        # download path entirely.
+        #
+        # The environment variables that would otherwise control this (HF_HOME,
+        # HF_HUB_OFFLINE) are no help: huggingface_hub reads them into constants
+        # at import time, and FunASR has already imported it by way of
+        # transformers before we get here.
+        model_dir = Path(model_id)
+        if not model_dir.is_dir():
+            model_dir = Path(
+                snapshot_download(
+                    # FunASR accepts short aliases ("paraformer-zh") as well as
+                    # repo ids; snapshot_download only knows repo ids.
+                    name_maps_hf.get(model_id, model_id),
+                    cache_dir=str(Path(cache_dir).resolve()),
+                    local_files_only=local_files_only,
+                )
+            )
 
         # FunASR prints a "funasr version: ..." banner to stdout when a model is
         # built. With the stdio:// transport that line corrupts the Wyoming
         # protocol, so redirect stdout to stderr while loading.
         with contextlib.redirect_stdout(sys.stderr):
             self.model = AutoModel(
-                model=model_id,
+                model=str(model_dir),
                 hub="hf",
                 device=torch_device(device),
                 disable_update=True,

--- a/wyoming_faster_whisper/models.py
+++ b/wyoming_faster_whisper/models.py
@@ -186,77 +186,129 @@ class ModelLoader:
             if transcriber is not None:
                 return transcriber
 
-            if stt_library == SttLibrary.SHERPA:
-                if streaming:
-                    from .sherpa_handler import SherpaStreamingTranscriber  # noqa: F811
-
-                    transcriber = SherpaStreamingTranscriber(
-                        model,
-                        self.download_dir,
-                        cpu_threads=self.cpu_threads,
-                        beam_size=self.beam_size,
-                        device=self.device,
-                    )
-                else:
-                    from .sherpa_handler import SherpaTranscriber  # noqa: F811
-
-                    transcriber = SherpaTranscriber(
-                        model,
-                        self.download_dir,
-                        cpu_threads=self.cpu_threads,
-                        device=self.device,
-                    )
-            elif stt_library == SttLibrary.ONNX_ASR:
-                from .onnx_asr_handler import OnnxAsrTranscriber  # noqa: F811
-
-                transcriber = OnnxAsrTranscriber(
-                    model,
-                    cache_dir=self.download_dir,
-                    local_files_only=self.local_files_only,
-                    device=self.device,
-                )
-            elif stt_library == SttLibrary.TRANSFORMERS:
-                from .transformers_whisper import TransformersTranscriber  # noqa: F811
-
-                transcriber = TransformersTranscriber(
-                    model,
-                    cache_dir=self.download_dir,
-                    local_files_only=self.local_files_only,
-                    device=self.device,
-                )
-            elif stt_library == SttLibrary.QWEN3_ASR:
-                from .qwen3_asr_handler import Qwen3AsrTranscriber  # noqa: F811
-
-                transcriber = Qwen3AsrTranscriber(
-                    model,
-                    cache_dir=self.download_dir,
-                    local_files_only=self.local_files_only,
-                    cpu_threads=self.cpu_threads,
-                    device=self.device,
-                )
-            elif stt_library == SttLibrary.FUNASR:
-                from .funasr_handler import FunASRTranscriber  # noqa: F811
-
-                transcriber = FunASRTranscriber(
-                    model,
-                    cache_dir=self.download_dir,
-                    local_files_only=self.local_files_only,
-                    device=self.device,
-                )
-            else:
-                transcriber = FasterWhisperTranscriber(
-                    model,
-                    cache_dir=self.download_dir,
-                    device=self.device,
-                    compute_type=self.compute_type,
-                    cpu_threads=self.cpu_threads,
-                    vad_parameters=self.vad_parameters,
-                    task=self.whisper_task,
-                )
-
+            transcriber = self._load_cache_first(stt_library, model, streaming)
             self._transcriber[key] = transcriber
 
         return transcriber
+
+    def _load_cache_first(
+        self, stt_library: SttLibrary, model: str, streaming: bool
+    ) -> Transcriber:
+        """Build a transcriber, preferring the cache over the network.
+
+        The hub check is what breaks when there is no internet, not the model
+        load: everything a cached model needs is already on disk. On a network
+        that blackholes outbound traffic (a Docker bridge marked `internal`) that
+        check stalls for the full TCP timeout on every start rather than failing
+        fast, which boot-loops the container. So try the cache first and only
+        reach for the network when a file is genuinely missing.
+
+        --local-files-only stays strict: no fallback, so a model that isn't
+        cached is an error instead of a surprise download.
+        """
+        if self.local_files_only:
+            return self._build_transcriber(
+                stt_library, model, streaming, local_files_only=True
+            )
+
+        try:
+            return self._build_transcriber(
+                stt_library, model, streaming, local_files_only=True
+            )
+        except OSError as exc:
+            # Every backend reports a cache miss as an OSError:
+            # huggingface_hub raises LocalEntryNotFoundError (a FileNotFoundError
+            # subclass), transformers raises a bare OSError, and the sherpa
+            # handler raises FileNotFoundError itself. A corrupt cache lands here
+            # too, and the retry below surfaces it as the download failing.
+            _LOGGER.debug("Model '%s' is not cached (%s), downloading", model, exc)
+
+        return self._build_transcriber(
+            stt_library, model, streaming, local_files_only=False
+        )
+
+    def _build_transcriber(
+        self,
+        stt_library: SttLibrary,
+        model: str,
+        streaming: bool,
+        local_files_only: bool,
+    ) -> Transcriber:
+        """Construct the transcriber for a backend."""
+        if stt_library == SttLibrary.SHERPA:
+            if streaming:
+                from .sherpa_handler import SherpaStreamingTranscriber  # noqa: F811
+
+                return SherpaStreamingTranscriber(
+                    model,
+                    self.download_dir,
+                    local_files_only=local_files_only,
+                    cpu_threads=self.cpu_threads,
+                    beam_size=self.beam_size,
+                    device=self.device,
+                )
+
+            from .sherpa_handler import SherpaTranscriber  # noqa: F811
+
+            return SherpaTranscriber(
+                model,
+                self.download_dir,
+                local_files_only=local_files_only,
+                cpu_threads=self.cpu_threads,
+                device=self.device,
+            )
+
+        if stt_library == SttLibrary.ONNX_ASR:
+            from .onnx_asr_handler import OnnxAsrTranscriber  # noqa: F811
+
+            return OnnxAsrTranscriber(
+                model,
+                cache_dir=self.download_dir,
+                local_files_only=local_files_only,
+                device=self.device,
+            )
+
+        if stt_library == SttLibrary.TRANSFORMERS:
+            from .transformers_whisper import TransformersTranscriber  # noqa: F811
+
+            return TransformersTranscriber(
+                model,
+                cache_dir=self.download_dir,
+                local_files_only=local_files_only,
+                device=self.device,
+            )
+
+        if stt_library == SttLibrary.QWEN3_ASR:
+            from .qwen3_asr_handler import Qwen3AsrTranscriber  # noqa: F811
+
+            return Qwen3AsrTranscriber(
+                model,
+                cache_dir=self.download_dir,
+                local_files_only=local_files_only,
+                cpu_threads=self.cpu_threads,
+                device=self.device,
+            )
+
+        if stt_library == SttLibrary.FUNASR:
+            from .funasr_handler import FunASRTranscriber  # noqa: F811
+
+            return FunASRTranscriber(
+                model,
+                cache_dir=self.download_dir,
+                local_files_only=local_files_only,
+                device=self.device,
+            )
+
+        return FasterWhisperTranscriber(
+            model,
+            cache_dir=self.download_dir,
+            local_files_only=local_files_only,
+            device=self.device,
+            compute_type=self.compute_type,
+            cpu_threads=self.cpu_threads,
+            vad_parameters=self.vad_parameters,
+            task=self.whisper_task,
+        )
 
     async def transcribe(
         self, wav_path: Union[str, Path], language: Optional[str]

--- a/wyoming_faster_whisper/sherpa_handler.py
+++ b/wyoming_faster_whisper/sherpa_handler.py
@@ -25,13 +25,23 @@ _URL_FORMAT = "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-model
 _TAIL_PADDING_SECONDS = 0.66
 
 
-def _ensure_model(model_id: str, cache_dir: Union[str, Path]) -> Path:
+def _ensure_model(
+    model_id: str, cache_dir: Union[str, Path], local_files_only: bool = False
+) -> Path:
     """Download/extract a sherpa-onnx model if needed and return its directory."""
     cache_dir = Path(cache_dir)
     model_dir = cache_dir / model_id
     _LOGGER.debug("Looking for sherpa model: %s", model_dir)
 
     if not model_dir.exists():
+        if local_files_only:
+            # FileNotFoundError so ModelLoader can treat a sherpa cache miss the
+            # same as huggingface_hub's LocalEntryNotFoundError.
+            raise FileNotFoundError(
+                f"Sherpa model '{model_id}' is not in {cache_dir} and downloading "
+                "is disabled by --local-files-only"
+            )
+
         url = _URL_FORMAT.format(model_id=model_id)
         _LOGGER.info("Downloading %s", url)
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -125,11 +135,12 @@ class SherpaTranscriber(Transcriber):
         self,
         model_id: str,
         cache_dir: Union[str, Path],
+        local_files_only: bool = False,
         cpu_threads: int = 4,
         device: str = "cpu",
     ) -> None:
         """Initialize model."""
-        model_dir = _ensure_model(model_id, cache_dir)
+        model_dir = _ensure_model(model_id, cache_dir, local_files_only)
         provider = _resolve_provider(device)
         prefer_int8 = provider == "cpu"
 
@@ -186,12 +197,13 @@ class SherpaStreamingTranscriber(Transcriber):
         self,
         model_id: str,
         cache_dir: Union[str, Path],
+        local_files_only: bool = False,
         cpu_threads: int = 4,
         beam_size: int = 5,
         device: str = "cpu",
     ) -> None:
         """Initialize model."""
-        model_dir = _ensure_model(model_id, cache_dir)
+        model_dir = _ensure_model(model_id, cache_dir, local_files_only)
         provider = _resolve_provider(device)
         prefer_int8 = provider == "cpu"
 


### PR DESCRIPTION
Fixes #93, fixes #92.

A model that is already downloaded now loads from disk without contacting Hugging Face, so a server on a network with no route out starts instead of boot-looping.

## What was wrong

`ModelLoader` passed `local_files_only` to the transformers, onnx-asr, qwen3-asr and funasr backends — but not to faster-whisper, the default one. `FasterWhisperTranscriber` never forwarded it to `WhisperModel`, so every start did a `repo_info()` round trip to huggingface.co. That is why [forcing the flag on in `__main__.py` had no effect](https://github.com/OHF-Voice/wyoming-faster-whisper/issues/93#issuecomment-5629135103).

`snapshot_download` does fall back to the cache, but only on `ConnectionError`/`Timeout`. A Docker bridge marked `internal` blackholes the SYN rather than refusing it, so the call stalls for the full TCP timeout — every start, and with `restart: always` that is a boot loop.

## Cache-first by default

Each backend is now built with `local_files_only=True` first and only retried as a download when construction raises `OSError` — `LocalEntryNotFoundError` ⊂ `FileNotFoundError` ⊂ `OSError` for huggingface_hub, a bare `OSError` from transformers, and `FileNotFoundError` from the sherpa handler. Nobody has to set a flag after the first download for this to work.

`--local-files-only` still means what it says: one attempt, no fallback, so a model that isn't cached is an error rather than a surprise download. Its help text said "don't check HuggingFace hub for updates every time", which is now the default behaviour; it now describes what the flag adds.

Sherpa models come from GitHub releases rather than the hub, so `_ensure_model` raises `FileNotFoundError` instead of downloading when the flag is set.

## FunASR needed more than plumbing

Two separate bugs, both of which would have defeated the fallback:

1. Its `os.environ.setdefault("HF_HOME", ...)` / `setdefault("HF_HUB_OFFLINE", "1")` calls were dead code. `huggingface_hub` reads those into `constants` at **import** time, and FunASR — by way of transformers — has already imported it before `__init__` runs. So FunASR ignored `--download-dir` entirely and put its ~900 MB of models in `~/.cache/huggingface`.
2. `download_from_hf` swallows download errors (`except Exception: print("Download: ... failed!")`) and carries on, failing several steps later with `RuntimeError: model ... is not registered`. That is not an `OSError`, so the cache-first retry could never see it.

The model directory is now resolved with `snapshot_download` before `AutoModel` is called; passing it a directory short-circuits FunASR's own download path. Short aliases (`paraformer-zh`) still work via `name_maps_hf`.

## Cache locations in the images

Both Dockerfiles now set:

```
ENV HF_HOME=/data XDG_CACHE_HOME=/data MODELSCOPE_CACHE=/data/modelscope
```

Model files already went to `/data` (every backend honours `--download-dir`, and hub 0.33 keeps `.locks` under the cache dir). What escaped is the **Xet chunk cache** — `$HF_HOME/xet`, several GB, and `cache_dir=` does not move it — plus torch and anything else falling back to `$XDG_CACHE_HOME`.

To be clear about the benefit: this is about writability and container disk, not persistence. The Xet cache is a transfer-time dedup cache, so losing it causes no re-downloads. It does fix the unwritable `/.cache` that a container running as a uid with no passwd entry hits, which is #92.

These have to be environment variables for the import-time reason above — setting them from Python would be too late.

## Testing

- Four new unit tests in `test_models.py`: cached model loads with one attempt, missing model falls back to downloading, `--local-files-only` does not fall back, and the transcriber is built once.
- Full suite: 258 passed, 2 xfailed. `script/lint` clean (black, isort, flake8, pylint 10.00, mypy).
- Offline path exercised by hand with `HF_ENDPOINT=https://127.0.0.1:9` to blackhole the hub: faster-whisper, funasr and sherpa all load cached models; uncached + `--local-files-only` fails fast with `LocalEntryNotFoundError` / `FileNotFoundError`.
- The FunASR fix is confirmed by the existing integration test, which downloaded SenseVoice into `local/` for the first time — previously it was silently reading the developer's `~/.cache`.

**Not verified:** neither image was built. Both pass `docker build --check`, but the `ENV` lines are untested at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
