### PR TITLE
Add VAD silence endpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add optional `--vad-endpointing SECONDS` server-side command endpointing, based
+  on speech-to-phrase's Silero VAD segmenter. It sends the transcript after the
+  configured post-speech silence instead of waiting for `audio-stop`, advertises
+  that external VAD is not required while enabled, and remains independent of
+  the transcription-time `--vad-filter` and `--vad-clip` options
+
 - Models that are already downloaded now load without contacting Hugging Face, so a server with no route to the internet starts instead of boot-looping (#93 by @schuylermartin45, #92)
   - Loading is cache-first by default: each backend is built with `local_files_only` and only retried as a download when a file is genuinely missing. The hub check is what fails without internet, not the model load, and on a network that drops outbound traffic rather than refusing it — a Docker bridge marked `internal` — it stalled for the full TCP timeout on every start
   - `--local-files-only` still means what it says: no fallback, so a model that isn't cached is an error rather than a surprise download. It had no effect at all on faster-whisper, the default backend, which never received the flag
@@ -164,4 +170,3 @@
 ## 1.0.0
 
 - Initial release
-

--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ if you want name biasing)
 
 **NOTE**: Models are downloaded to the first `--data-dir` directory.
 
+## Server-side VAD Endpointing
+
+By default, the server waits for the client to send `audio-stop` before it
+transcribes. Set `--vad-endpointing` to a number of seconds to end the command
+after that much Silero-detected silence and send the transcript immediately:
+
+```sh
+script/run --uri 'tcp://0.0.0.0:10300' --data-dir /data \
+    --vad-endpointing 0.7
+```
+
+When enabled, the Wyoming service advertises that it does not require external
+VAD, so Home Assistant leaves endpointing to this server. Speech must be detected
+before the silence timer starts; brief pauses reset when speech resumes, and a
+command is allowed to run for at least one second. Audio received after the
+endpoint is ignored until the client's eventual `audio-stop`.
+
+This is independent of the existing VAD options. `--vad-filter` still controls
+Faster Whisper's filtering during transcription, while `--vad-clip` still trims
+the completed batch WAV before transcription. They can be used together with
+`--vad-endpointing`; the only intentional interaction is replacing Home
+Assistant's external endpointing while this option is enabled.
+
 ## Biasing Toward Your Home Assistant Names
 
 Whisper has never heard of your thermostat. "What's the temperature of the Ecobee?"
@@ -311,6 +334,7 @@ underscores and a `WYO_WHISPER_` prefix:
 | `--model` | `WYO_WHISPER_MODEL` |
 | `--language` | `WYO_WHISPER_LANGUAGE` |
 | `--stt-library` | `WYO_WHISPER_STT_LIBRARY` |
+| `--vad-endpointing` | `WYO_WHISPER_VAD_ENDPOINTING` |
 | `--hass-token` | `WYO_WHISPER_HASS_TOKEN` |
 | ...and so on for every option in `--help` | |
 

--- a/tests/test_dispatch_handler.py
+++ b/tests/test_dispatch_handler.py
@@ -175,8 +175,17 @@ def _names(*entities) -> RecognitionContext:
     return RecognitionContext(priority_entities=list(entities))
 
 
-def _handler(transcriber, names=None, initial_prompt=None) -> Handler:
-    return Handler(Info(), FakeLoader(transcriber, initial_prompt), names, None, None)
+def _handler(
+    transcriber, names=None, initial_prompt=None, vad_endpointing=None
+) -> Handler:
+    return Handler(
+        Info(),
+        FakeLoader(transcriber, initial_prompt),
+        names,
+        None,
+        None,
+        vad_endpointing=vad_endpointing,
+    )
 
 
 def _cache(hass, **kwargs) -> HassNameCache:
@@ -379,6 +388,39 @@ async def test_audio_stop_with_no_audio_returns_an_empty_transcript():
 
     assert handler.transcript == ""
     assert not transcriber.calls
+
+
+class ImmediateEndpoint:
+    def reset(self) -> None:
+        pass
+
+    def process(self, _audio: bytes) -> bool:
+        return False
+
+
+async def test_vad_endpointing_sends_one_transcript_before_audio_stop():
+    transcriber = FakeTranscriber()
+    handler = _handler(transcriber, vad_endpointing=0.7)
+    handler._endpoint_detector = ImmediateEndpoint()
+
+    await handler.handle_event(AudioStart(rate=RATE, width=2, channels=1).event())
+    await handler.handle_event(
+        AudioChunk(audio=b"\x00\x00" * 160, rate=RATE, width=2, channels=1).event()
+    )
+
+    assert handler.transcript == "fake transcript"
+    assert len(transcriber.calls) == 1
+
+    # Chunks sent while the client is still working toward AudioStop are ignored,
+    # and AudioStop does not generate a duplicate transcript.
+    await handler.handle_event(
+        AudioChunk(audio=b"\x00\x00" * 160, rate=RATE, width=2, channels=1).event()
+    )
+    await handler.handle_event(AudioStop().event())
+
+    transcripts = [event for event in handler.written if Transcript.is_type(event.type)]
+    assert len(transcripts) == 1
+    assert len(transcriber.calls) == 1
 
 
 # --- streaming path ------------------------------------------------------

--- a/tests/test_endpointing.py
+++ b/tests/test_endpointing.py
@@ -1,0 +1,57 @@
+"""Tests for optional pySilero end-of-command detection."""
+
+from typing import Iterable, List
+
+from wyoming_faster_whisper import endpointing
+from wyoming_faster_whisper.__main__ import build_info
+
+
+class ProbabilityDetector:
+    def __init__(self, probabilities: Iterable[float]) -> None:
+        self.probabilities = iter(probabilities)
+        self.resets = 0
+
+    def reset(self) -> None:
+        self.resets += 1
+
+    def process_samples(self, _samples: List[float]) -> float:
+        return next(self.probabilities)
+
+
+def pcm_chunks(count: int) -> bytes:
+    return b"\x00\x00" * endpointing.SAMPLES_PER_VAD_CHUNK * count
+
+
+def test_silero_endpoint_requires_speech_then_silence() -> None:
+    probabilities = [0.0] * 20 + [0.9] * 10 + [0.0] * 22
+    detector = ProbabilityDetector(probabilities)
+    endpoint = endpointing.SileroEndpointDetector(0.7, detector)
+    endpoint.reset()
+
+    assert endpoint.process(pcm_chunks(20))
+    assert endpoint.process(pcm_chunks(10))
+    assert not endpoint.process(pcm_chunks(22))
+    assert detector.resets == 1
+
+
+def test_speech_resets_silence_countdown() -> None:
+    probabilities = [0.9] * 10 + [0.0] * 15 + [0.9] + [0.0] * 22
+    endpoint = endpointing.SileroEndpointDetector(
+        0.7, ProbabilityDetector(probabilities)
+    )
+    endpoint.reset()
+
+    assert endpoint.process(pcm_chunks(10))
+    assert endpoint.process(pcm_chunks(15))
+    assert endpoint.process(pcm_chunks(1))
+    assert endpoint.process(pcm_chunks(21))
+    assert not endpoint.process(pcm_chunks(1))
+
+
+def test_server_vad_disables_home_assistant_endpointing() -> None:
+    assert build_info("model").asr[0].requires_external_vad
+    assert (
+        not build_info("model", requires_external_vad=False)
+        .asr[0]
+        .requires_external_vad
+    )

--- a/tests/test_env_args.py
+++ b/tests/test_env_args.py
@@ -55,9 +55,14 @@ def test_command_line_wins() -> None:
 
 def test_type_conversion() -> None:
     """Values go through the option's own type."""
-    args = run(WYO_WHISPER_BEAM_SIZE="3", WYO_WHISPER_VAD_THRESHOLD="0.25")
+    args = run(
+        WYO_WHISPER_BEAM_SIZE="3",
+        WYO_WHISPER_VAD_THRESHOLD="0.25",
+        WYO_WHISPER_VAD_ENDPOINTING="0.7",
+    )
     assert args.beam_size == 3
     assert args.vad_threshold == 0.25
+    assert args.vad_endpointing == 0.7
 
 
 def test_invalid_type(capsys: pytest.CaptureFixture) -> None:
@@ -66,6 +71,13 @@ def test_invalid_type(capsys: pytest.CaptureFixture) -> None:
         run(WYO_WHISPER_BEAM_SIZE="large")
 
     assert "WYO_WHISPER_BEAM_SIZE" in capsys.readouterr().err
+
+
+def test_vad_endpointing_must_be_positive(capsys: pytest.CaptureFixture) -> None:
+    with pytest.raises(SystemExit):
+        run(WYO_WHISPER_VAD_ENDPOINTING="0")
+
+    assert "WYO_WHISPER_VAD_ENDPOINTING" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])

--- a/wyoming_faster_whisper/__main__.py
+++ b/wyoming_faster_whisper/__main__.py
@@ -32,6 +32,14 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def positive_float(value: str) -> float:
+    """Parse a strictly positive floating-point command-line value."""
+    number = float(value)
+    if number <= 0:
+        raise ValueError("must be greater than zero")
+    return number
+
+
 def get_parser() -> argparse.ArgumentParser:
     """Return the command-line parser.
 
@@ -130,6 +138,12 @@ def get_parser() -> argparse.ArgumentParser:
         type=int,
         default=2000,
         help="VAD minimum silence duration in ms to split (default: 2000, faster-whisper only)",
+    )
+    parser.add_argument(
+        "--vad-endpointing",
+        type=positive_float,
+        help="End a command and send its transcript after this many seconds of "
+        "VAD-detected silence (default: wait for audio-stop)",
     )
     parser.add_argument(
         "--vad-clip",
@@ -263,39 +277,9 @@ async def main() -> None:
     if args.model == AUTO_MODEL:
         args.model = None
 
-    wyoming_info = Info(
-        asr=[
-            AsrProgram(
-                name="faster-whisper",
-                description="Faster Whisper transcription with CTranslate2",
-                attribution=Attribution(
-                    name="Guillaume Klein",
-                    url="https://github.com/guillaumekln/faster-whisper/",
-                ),
-                installed=True,
-                version=__version__,
-                models=[
-                    AsrModel(
-                        name=model_name,
-                        description=model_name,
-                        attribution=Attribution(
-                            name="Systran",
-                            url="https://huggingface.co/Systran",
-                        ),
-                        installed=True,
-                        languages=sorted(
-                            list(
-                                # pylint: disable=protected-access
-                                set(faster_whisper.tokenizer._LANGUAGE_CODES).union(
-                                    PARAKEET_LANGUAGES
-                                )
-                            )
-                        ),
-                        version=faster_whisper.__version__,
-                    )
-                ],
-            )
-        ],
+    wyoming_info = build_info(
+        model_name,
+        requires_external_vad=args.vad_endpointing is None,
     )
 
     vad_parameters: Optional[Dict[str, Any]] = None
@@ -356,7 +340,47 @@ async def main() -> None:
             wyoming_info,
             loader,
             names,
+            vad_endpointing=args.vad_endpointing,
         )
+    )
+
+
+def build_info(model_name: str, *, requires_external_vad: bool = True) -> Info:
+    """Build Wyoming service metadata."""
+    return Info(
+        asr=[
+            AsrProgram(
+                name="faster-whisper",
+                description="Faster Whisper transcription with CTranslate2",
+                attribution=Attribution(
+                    name="Guillaume Klein",
+                    url="https://github.com/guillaumekln/faster-whisper/",
+                ),
+                installed=True,
+                version=__version__,
+                requires_external_vad=requires_external_vad,
+                models=[
+                    AsrModel(
+                        name=model_name,
+                        description=model_name,
+                        attribution=Attribution(
+                            name="Systran",
+                            url="https://huggingface.co/Systran",
+                        ),
+                        installed=True,
+                        languages=sorted(
+                            list(
+                                # pylint: disable=protected-access
+                                set(faster_whisper.tokenizer._LANGUAGE_CODES).union(
+                                    PARAKEET_LANGUAGES
+                                )
+                            )
+                        ),
+                        version=faster_whisper.__version__,
+                    )
+                ],
+            )
+        ],
     )
 
 

--- a/wyoming_faster_whisper/dispatch_handler.py
+++ b/wyoming_faster_whisper/dispatch_handler.py
@@ -15,6 +15,7 @@ from wyoming.info import Describe, Info
 from wyoming.server import AsyncEventHandler
 
 from .const import StreamingSession, Transcriber
+from .endpointing import SileroEndpointDetector
 from .models import ModelLoader
 from .vad import clip_wav_to_speech
 
@@ -35,14 +36,20 @@ class DispatchEventHandler(AsyncEventHandler):
         loader: ModelLoader,
         names: Optional["HassNameCache"],
         *args,
+        vad_endpointing: Optional[float] = None,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
 
         self.wyoming_info_event = wyoming_info.event()
+        if vad_endpointing is not None and vad_endpointing <= 0:
+            raise ValueError("vad_endpointing must be greater than zero")
 
         self._loader = loader
         self._names = names
+        self._vad_endpointing = vad_endpointing
+        self._endpoint_detector: Optional[SileroEndpointDetector] = None
+        self._finished = False
         self._transcriber: Optional[Transcriber] = None
         self._transcriber_future: Optional[asyncio.Future] = None
         self._language: Optional[str] = None
@@ -68,6 +75,9 @@ class DispatchEventHandler(AsyncEventHandler):
 
     async def handle_event(self, event: Event) -> bool:
         if AudioStart.is_type(event.type):
+            self._finished = False
+            self._reset_endpoint_detector()
+
             # Start refreshing Home Assistant's names now. The speaker is still
             # talking, so the fetch has the length of their command to finish in
             # and costs no latency at all.
@@ -75,6 +85,9 @@ class DispatchEventHandler(AsyncEventHandler):
             return True
 
         if AudioChunk.is_type(event.type):
+            if self._finished:
+                return True
+
             chunk = self._audio_converter.convert(AudioChunk.from_event(event))
             self._got_audio = True
 
@@ -108,76 +121,25 @@ class DispatchEventHandler(AsyncEventHandler):
                 # Transcriber not ready yet: buffer until the path is known.
                 self._pending_audio.append(chunk.audio)
 
+            if self._vad_endpointing is not None:
+                if self._endpoint_detector is None:
+                    # Safety net for clients that send chunks without AudioStart.
+                    self._reset_endpoint_detector()
+
+                assert self._endpoint_detector is not None
+                if not self._endpoint_detector.process(chunk.audio):
+                    _LOGGER.debug(
+                        "Voice command ended after %.3f seconds of VAD silence",
+                        self._vad_endpointing,
+                    )
+                    await self._finish_utterance()
+
             return True
 
         if AudioStop.is_type(event.type):
             _LOGGER.debug("Audio stopped")
-            start_time = time.monotonic()
-
-            # No audio was received before AudioStop — return empty transcript.
-            # This happens when HA sends AudioStop without any AudioChunk
-            # (e.g., VAD detected no speech, or the client disconnected early).
-            if not self._got_audio:
-                _LOGGER.warning("AudioStop received with no audio data")
-                await self.write_event(Transcript(text="").event())
-                self._reset()
-                return False
-
-            # Get the transcriber that was loading in the background.
-            if self._transcriber is None:
-                if self._transcriber_future is None:
-                    _LOGGER.warning("No transcriber available")
-                    await self.write_event(Transcript(text="").event())
-                    self._reset()
-                    return False
-                self._transcriber = await self._transcriber_future
-
-            # If audio arrived before the transcriber was ready, the path may
-            # still be undecided — commit it now using the buffered audio.
-            if self._is_streaming is None:
-                await self._commit_path()
-
-            if self._is_streaming:
-                assert self._session is not None
-                text = await asyncio.to_thread(self._session.finish)
-            else:
-                assert self._wav_file is not None
-                self._wav_file.close()
-                self._wav_file = None
-
-                # Optionally clip leading/trailing silence before transcription.
-                # This operates on the WAV, so any batch transcriber can use it;
-                # --vad-clip decides which libraries actually do. Streaming
-                # transcribers never reach this path.
-                wav_path = self._wav_path
-                if self._loader.should_vad_clip(
-                    self._language
-                ) and await asyncio.to_thread(
-                    clip_wav_to_speech,
-                    self._wav_path,
-                    self._clipped_wav_path,
-                    self._loader.vad_clip_threshold,
-                    self._loader.vad_clip_pad_ms,
-                ):
-                    wav_path = self._clipped_wav_path
-
-                # Do transcription in a separate thread
-                text = await asyncio.to_thread(
-                    self._transcriber.transcribe,
-                    wav_path,
-                    self._language,
-                    beam_size=self._loader.beam_size,
-                    initial_prompt=await self._initial_prompt(),
-                )
-
-            end_time = time.monotonic()
-            _LOGGER.info(text)
-
-            await self.write_event(Transcript(text=text).event())
-            _LOGGER.debug("Completed request in %s second(s)", end_time - start_time)
-
+            await self._finish_utterance()
             self._reset()
-
             return False
 
         if Transcribe.is_type(event.type):
@@ -193,6 +155,79 @@ class DispatchEventHandler(AsyncEventHandler):
             return True
 
         return True
+
+    async def _finish_utterance(self) -> None:
+        """Transcribe and answer the current stream exactly once."""
+        if self._finished:
+            return
+
+        self._finished = True
+        start_time = time.monotonic()
+
+        # No audio was received before the stream ended.
+        if not self._got_audio:
+            _LOGGER.warning("Finishing utterance with no audio data")
+            await self.write_event(Transcript(text="").event())
+            return
+
+        # Get the transcriber that was loading in the background.
+        if self._transcriber is None:
+            if self._transcriber_future is None:
+                _LOGGER.warning("No transcriber available")
+                await self.write_event(Transcript(text="").event())
+                return
+            self._transcriber = await self._transcriber_future
+
+        # If audio arrived before the transcriber was ready, the path may
+        # still be undecided — commit it now using the buffered audio.
+        if self._is_streaming is None:
+            await self._commit_path()
+
+        if self._is_streaming:
+            assert self._session is not None
+            text = await asyncio.to_thread(self._session.finish)
+        else:
+            assert self._wav_file is not None
+            self._wav_file.close()
+            self._wav_file = None
+
+            # Optionally clip leading/trailing silence before transcription.
+            # This operates on the WAV, so any batch transcriber can use it;
+            # --vad-clip decides which libraries actually do. Streaming
+            # transcribers never reach this path.
+            wav_path = self._wav_path
+            if self._loader.should_vad_clip(self._language) and await asyncio.to_thread(
+                clip_wav_to_speech,
+                self._wav_path,
+                self._clipped_wav_path,
+                self._loader.vad_clip_threshold,
+                self._loader.vad_clip_pad_ms,
+            ):
+                wav_path = self._clipped_wav_path
+
+            # Do transcription in a separate thread
+            text = await asyncio.to_thread(
+                self._transcriber.transcribe,
+                wav_path,
+                self._language,
+                beam_size=self._loader.beam_size,
+                initial_prompt=await self._initial_prompt(),
+            )
+
+        end_time = time.monotonic()
+        _LOGGER.info(text)
+
+        await self.write_event(Transcript(text=text).event())
+        _LOGGER.debug("Completed request in %s second(s)", end_time - start_time)
+
+    def _reset_endpoint_detector(self) -> None:
+        """Create or reset endpointing for a new normalized audio stream."""
+        if self._vad_endpointing is None:
+            return
+
+        if self._endpoint_detector is None:
+            self._endpoint_detector = SileroEndpointDetector(self._vad_endpointing)
+        self._endpoint_detector.reset()
 
     def _refresh_names(self) -> None:
         """Kick off one background refresh of Home Assistant's names per utterance.
@@ -273,6 +308,7 @@ class DispatchEventHandler(AsyncEventHandler):
         self._language = None
         self._transcriber = None
         self._transcriber_future = None
+        self._finished = False
         self._got_audio = False
         self._is_streaming = None
         self._session = None

--- a/wyoming_faster_whisper/endpointing.py
+++ b/wyoming_faster_whisper/endpointing.py
@@ -1,0 +1,135 @@
+"""Optional server-side voice-command endpoint detection."""
+
+from typing import List, Optional, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+SAMPLE_RATE = 16000
+SAMPLES_PER_VAD_CHUNK = 512
+SECONDS_PER_VAD_CHUNK = SAMPLES_PER_VAD_CHUNK / SAMPLE_RATE
+
+
+class SpeechProbabilityDetector(Protocol):
+    """Stateful detector that scores one 16 kHz mono sample window."""
+
+    def reset(self) -> None:
+        pass
+
+    def process_samples(self, samples: List[float]) -> float:
+        pass
+
+
+class VoiceCommandSegmenter:
+    """Detect the end of speech without treating brief pauses as an endpoint."""
+
+    def __init__(
+        self,
+        silence_seconds: float,
+        *,
+        speech_seconds: float = 0.3,
+        command_seconds: float = 1.0,
+        before_command_speech_threshold: float = 0.2,
+        in_command_speech_threshold: float = 0.5,
+    ) -> None:
+        if silence_seconds <= 0:
+            raise ValueError("silence_seconds must be greater than zero")
+        if speech_seconds <= 0:
+            raise ValueError("speech_seconds must be greater than zero")
+        if command_seconds < speech_seconds:
+            raise ValueError("command_seconds must be at least speech_seconds")
+
+        self.silence_seconds = silence_seconds
+        self.speech_seconds = speech_seconds
+        self.command_seconds = command_seconds
+        self.before_command_speech_threshold = before_command_speech_threshold
+        self.in_command_speech_threshold = in_command_speech_threshold
+        self.in_command = False
+        self._speech_seconds_left = 0.0
+        self._command_seconds_left = 0.0
+        self._silence_seconds_left = 0.0
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset state for a new audio stream."""
+        self.in_command = False
+        self._speech_seconds_left = self.speech_seconds
+        self._command_seconds_left = self.command_seconds - self.speech_seconds
+        self._silence_seconds_left = self.silence_seconds
+
+    def process(self, chunk_seconds: float, speech_probability: float) -> bool:
+        """Return False when a started voice command has ended."""
+        if not self.in_command:
+            if speech_probability > self.before_command_speech_threshold:
+                self._speech_seconds_left -= chunk_seconds
+                if self._speech_seconds_left <= 0:
+                    self.in_command = True
+            else:
+                self._speech_seconds_left = self.speech_seconds
+            return True
+
+        self._command_seconds_left -= chunk_seconds
+        if speech_probability > self.in_command_speech_threshold:
+            self._silence_seconds_left = self.silence_seconds
+        else:
+            self._silence_seconds_left -= chunk_seconds
+
+        if self._command_seconds_left <= 0 and self._silence_seconds_left <= 0:
+            self.reset()
+            return False
+
+        return True
+
+
+class SileroEndpointDetector:
+    """Detect endpoints in normalized 16 kHz, 16-bit, mono PCM."""
+
+    def __init__(
+        self,
+        silence_seconds: float,
+        detector: Optional[SpeechProbabilityDetector] = None,
+    ) -> None:
+        if detector is None:
+            from pysilero_vad import SileroVoiceActivityDetector
+
+            detector = SileroVoiceActivityDetector()
+
+        self._vad = detector
+        self._segmenter = VoiceCommandSegmenter(silence_seconds)
+        self._pending = np.empty(0, dtype=np.float32)
+
+    def reset(self) -> None:
+        """Reset VAD state for a new Wyoming audio stream."""
+        self._vad.reset()
+        self._segmenter.reset()
+        self._pending = np.empty(0, dtype=np.float32)
+
+    def process(self, audio: bytes) -> bool:
+        """Return False when enough post-command silence has been observed."""
+        samples = _decode_pcm(audio)
+        if not samples.size:
+            return True
+
+        self._pending = np.concatenate((self._pending, samples))
+        offset = 0
+        while (offset + SAMPLES_PER_VAD_CHUNK) <= self._pending.size:
+            vad_chunk = self._pending[offset : offset + SAMPLES_PER_VAD_CHUNK]
+            probability = float(self._vad.process_samples(vad_chunk.tolist()))
+            offset += SAMPLES_PER_VAD_CHUNK
+            if not self._segmenter.process(SECONDS_PER_VAD_CHUNK, probability):
+                self._pending = np.empty(0, dtype=np.float32)
+                return False
+
+        if offset:
+            self._pending = self._pending[offset:].copy()
+        return True
+
+
+def _decode_pcm(audio: bytes) -> NDArray[np.float32]:
+    """Decode normalized 16-bit PCM to float32."""
+    if len(audio) % 2:
+        raise ValueError("audio chunk contains a partial sample")
+
+    samples = np.frombuffer(audio, dtype="<i2").astype(np.float32)
+    samples /= 32768.0
+    return samples


### PR DESCRIPTION
Add `--vad-endpointing <seconds>` to use Silero VAD to check for silence at the end of a command and stop. By default, Home Assistant will detect the end.